### PR TITLE
Improve contribution process: bulk evidence path and template fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/evidence-submission.md
+++ b/.github/ISSUE_TEMPLATE/evidence-submission.md
@@ -19,7 +19,14 @@ assignees: Daphnis605
 
 ---
 
-## The evidence
+## What does this evidence show?
+
+**In one or two sentences, what does this source show? (max 300 characters)**
+<!-- Explain specifically how this evidences the recommendation being *implemented*, not just accepted or promised. Put this first so it appears in notification previews. -->
+
+---
+
+## Source details
 
 **URL:**
 <!-- Must be a direct link to the evidence — legislation.gov.uk, gov.uk, parliament.uk, or a reputable news source. No link shorteners. -->
@@ -33,9 +40,6 @@ assignees: Daphnis605
 
 **Date of the source (approximate is fine):**
 <!-- e.g. April 2025 -->
-
-**In one or two sentences, what does this source show?**
-<!-- Explain specifically how this evidences the recommendation being *implemented*, not just accepted or promised. -->
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,30 @@ If you spot an error in a recommendation, its category, or its change type:
 
 ---
 
-### 3. Submit a pull request
+### 3. Submit bulk evidence (official datasets)
+
+If you have a structured dataset — an official government implementation tracker, a published CSV, or a report covering many recommendations at once — raising individual issues would send a notification per row to every repository watcher. Use a pull request instead.
+
+**When to use this path:**
+- You have evidence covering 5 or more recommendations from the same inquiry
+- The source is an official government or inquiry body publication
+- You can map each row to a specific recommendation in `enriched_data.json`
+
+**How to submit:**
+1. Fork the repository
+2. Update `enriched_data.json` directly — add entries keyed by `InquiryName__index` (where index is the 1-based position of the recommendation within that inquiry in `data.json`)
+3. Set `"approved": false` on all new entries — the maintainer approves after review
+4. If the source file is not publicly hosted, commit it to `raw_data/`
+5. Open a pull request with the title: `Bulk evidence: [Inquiry name] — [source name/date]`
+6. In the PR body, list the data source URL, the number of recommendations covered, and flag any matching uncertainty (e.g. "Rec 6a-vi mapped by text overlap — please verify")
+
+**CI will automatically validate** the JSON schema and spot-check any URLs you provide.
+
+This path is intended for maintainers and trusted contributors who are familiar with the data schema. If you are unsure, use the issue template instead.
+
+---
+
+### 4. Submit a pull request
 
 For code or schema changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,23 @@ If you spot an error in a recommendation, its category, or its change type:
 
 ---
 
-### 3. Submit bulk evidence (official datasets)
+### 3. Submit a pull request
+
+For code or schema changes:
+
+1. Fork the repository
+2. Create a branch: `feature/your-change` or `fix/your-fix`
+3. Make your changes
+4. Open a pull request using the PR template
+5. CI will run automatically — fix any failures before requesting review
+
+All PRs must pass CI validation before they can be merged. The maintainer reviews all PRs.
+
+---
+
+### 4. Submit bulk evidence (official datasets)
+
+> **For maintainers and trusted contributors only.** If you are an external contributor with a single piece of evidence, use the issue template in Section 1.
 
 If you have a structured dataset — an official government implementation tracker, a published CSV, or a report covering many recommendations at once — raising individual issues would send a notification per row to every repository watcher. Use a pull request instead.
 
@@ -53,27 +69,11 @@ If you have a structured dataset — an official government implementation track
 1. Fork the repository
 2. Update `enriched_data.json` directly — add entries keyed by `InquiryName__index` (where index is the 1-based position of the recommendation within that inquiry in `data.json`)
 3. Set `"approved": false` on all new entries — the maintainer approves after review
-4. If the source file is not publicly hosted, commit it to `raw_data/`
+4. If the source file is not publicly hosted, commit it to the repository alongside your changes
 5. Open a pull request with the title: `Bulk evidence: [Inquiry name] — [source name/date]`
 6. In the PR body, list the data source URL, the number of recommendations covered, and flag any matching uncertainty (e.g. "Rec 6a-vi mapped by text overlap — please verify")
 
-**CI will automatically validate** the JSON schema and spot-check any URLs you provide.
-
-This path is intended for maintainers and trusted contributors who are familiar with the data schema. If you are unsure, use the issue template instead.
-
----
-
-### 4. Submit a pull request
-
-For code or schema changes:
-
-1. Fork the repository
-2. Create a branch: `feature/your-change` or `fix/your-fix`
-3. Make your changes
-4. Open a pull request using the PR template
-5. CI will run automatically — fix any failures before requesting review
-
-All PRs must pass CI validation before they can be merged. The maintainer reviews all PRs.
+**CI will automatically validate** the JSON schema and spot-check any URLs you provide. CI will also fail until all entries are reviewed — this is expected and signals that maintainer review is required before merging.
 
 ---
 
@@ -101,7 +101,7 @@ You will receive a notification on your GitHub issue when a decision is made.
 
 ### For bulk data PRs
 
-When a PR adds multiple evidence entries directly to `enriched_data.json` (section 3 above):
+When a PR adds multiple evidence entries directly to `enriched_data.json` (section 4 above):
 
 1. The PR is opened — all new entries have `approved: false`
 2. **CI fails immediately** — this is expected and signals that review is required


### PR DESCRIPTION
## Summary

- **Issue template**: moved 'What does this evidence show?' to the top of the template body so it appears in watcher notification previews instead of being cut off; added 300-character limit hint
- **CONTRIBUTING.md**: added section 3 — 'Submit bulk evidence (official datasets)' — explaining when to use a direct PR to `enriched_data.json` rather than individual GitHub issues (reduces notification noise for large datasets)

## Why
Raising 58 individual issues for the IBI tracker CSV generated 58 watcher notifications. Large official datasets should come in as a single PR, not issue-per-row. The issue template fix ensures the key description is visible in email notifications.

## No data changes
This PR does not touch `enriched_data.json` or `data.json` — CI validation will pass without URL checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)