### PR TITLE
Document evidence review workflow (CONTRIBUTING.md + review app README)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,47 @@ All PRs must pass CI validation before they can be merged. The maintainer review
 
 All submitted evidence is reviewed by the maintainer before it appears on the dashboard. This is not because we distrust contributors — it is because the project's credibility depends entirely on accuracy.
 
-The review process:
+Every piece of evidence enters the system with `approved: false` and is **never shown publicly** until a maintainer has read it and explicitly approved it. CI enforces this: a PR cannot be merged if it contains any unapproved evidence items.
+
+---
+
+### For single issue submissions
+
+When you open an evidence submission issue, the process is:
+
 1. CI checks that the URL is accessible (HEAD request)
 2. The maintainer reads the recommendation text and the evidence side by side
-3. The maintainer decides: Approve / Reject / Needs more research
-4. Approved evidence is committed to `enriched_data.json` with `approved: true`
-5. The dashboard is updated automatically when the PR merges
+3. The maintainer decides: **Approve** / **Reject** / **Needs more research**
+4. If approved, the evidence is added to `enriched_data.json` with `approved: true` and the PR is merged
+5. The dashboard updates automatically
 
 You will receive a notification on your GitHub issue when a decision is made.
+
+---
+
+### For bulk data PRs
+
+When a PR adds multiple evidence entries directly to `enriched_data.json` (section 3 above):
+
+1. The PR is opened — all new entries have `approved: false`
+2. **CI fails immediately** — this is expected and signals that review is required
+3. The maintainer checks out the branch and runs the local review app:
+   ```
+   git checkout <branch-name>
+   python tools/review_app/app.py
+   # opens http://localhost:5000
+   ```
+4. Each entry is reviewed side by side with the recommendation text; entries are approved or rejected
+5. The maintainer commits the reviewed file and pushes:
+   ```
+   git add enriched_data.json
+   git commit -m "Review: approve evidence entries"
+   git push
+   ```
+6. CI now passes — the PR can be merged
+7. The dashboard updates automatically
+
+See [tools/review_app/README.md](tools/review_app/README.md) for full instructions on running the review app.
 
 ---
 

--- a/tools/review_app/README.md
+++ b/tools/review_app/README.md
@@ -1,0 +1,82 @@
+# Evidence Review App
+
+A local Flask app for reviewing and approving evidence entries in `enriched_data.json`. Used by the maintainer to work through bulk data PRs before they can be merged.
+
+---
+
+## When to use this
+
+Any PR that adds entries to `enriched_data.json` will **fail CI** until all entries have `approved: true`. The review app is the tool for doing that review.
+
+If you have opened a single-evidence GitHub Issue instead of a bulk PR, you do not need this app — use it only for PRs.
+
+---
+
+## Prerequisites
+
+Python 3.9+ and Flask:
+
+```bash
+pip install flask
+```
+
+---
+
+## Workflow: reviewing a bulk data PR
+
+**Step 1 — Check out the branch**
+
+```bash
+git fetch origin
+git checkout feature/evidence-ibi   # or whichever branch the PR is on
+```
+
+**Step 2 — Start the review app**
+
+```bash
+python tools/review_app/app.py
+```
+
+Open http://localhost:5000 in your browser.
+
+**Step 3 — Review each entry**
+
+The app shows every `approved: false` evidence item grouped by inquiry. For each item you will see:
+
+- The **recommendation text** (from `data.json`) — what the inquiry actually recommended
+- The **evidence title, source, date, and description** — what the submission claims as evidence
+
+For each item, choose one of:
+
+| Action | What it does |
+|---|---|
+| **Approve** | Sets `approved: true` — entry will appear publicly once the PR is merged |
+| **Reject** | Permanently removes the evidence item — use if the evidence does not support the recommendation |
+| **Set status** | Updates `evidence_status` for the recommendation (`actioned`, `partial`, `no_evidence_found`, `not_published`) |
+
+> **Warning:** Reject is permanent and cannot be undone within the app. If you reject by mistake, re-run the original data import script or restore from git.
+
+Changes are written to `enriched_data.json` immediately on each action. You do not need to save manually.
+
+**Step 4 — Commit and push**
+
+Once you have reviewed all entries:
+
+```bash
+git add enriched_data.json
+git commit -m "Review: approve evidence entries — [Inquiry name]"
+git push
+```
+
+**Step 5 — CI passes, merge the PR**
+
+The CI check (`Check all evidence items are approved before merging`) will now pass. The PR is ready to merge.
+
+---
+
+## Notes
+
+- The app runs on `localhost:5000` only — it is not accessible from other machines
+- Debug mode is off by default. To enable it for development: `FLASK_DEBUG=1 python tools/review_app/app.py`
+- The app reads `enriched_data.json` and `data.json` from the repository root (two levels up from this file)
+- If you need to restart mid-review, progress is already saved — the app reads the current state of the file on each page load


### PR DESCRIPTION
## Summary

Closes the documentation gap around the review workflow — contributors and the maintainer now have clear written guidance on what happens after evidence is submitted.

**CONTRIBUTING.md** — expanded 'Evidence review process' into two tracks:
- Single issue submissions: existing flow, unchanged
- Bulk data PRs: explains the CI gate, `approved:false` convention, and the step-by-step process (checkout → run app → review → commit → push → CI passes → merge)

**tools/review_app/README.md** (new) — maintainer reference:
- When to use the app
- Prerequisites
- Full 5-step workflow with exact commands
- Action reference table (Approve / Reject / Set status)
- Warning that Reject is permanent

## Merge order

Can merge any time after [#131](../../pull/131) (process docs) — no dependency on the data PRs or CI gate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)