### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
       - 'enriched_data.json'
       - 'schema/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Daphnis605/uk_inquiry_dashboard/security/code-scanning/1](https://github.com/Daphnis605/uk_inquiry_dashboard/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults. For this workflow, `contents: read` is the appropriate minimal permission because it checks out and reads repository files but does not need write scopes.

Best single fix (no functional change):
- Edit `.github/workflows/validate.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it near the top-level keys (e.g., after `on:` block and before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
