### PR TITLE
Add evidence_type field to review app

### DIFF
--- a/.github/ISSUE_TEMPLATE/evidence-submission.md
+++ b/.github/ISSUE_TEMPLATE/evidence-submission.md
@@ -38,6 +38,10 @@ assignees: Daphnis605
 - [ ] Press release
 - [ ] News article
 
+**Evidence type:** (select one)
+- [ ] **Partial** — shows progress towards implementation (e.g. government accepted, steps underway, consultation launched)
+- [ ] **Complete** — shows the recommendation has been fully implemented (e.g. law enacted, scheme operational, policy in force)
+
 **Date of the source (approximate is fine):**
 <!-- e.g. April 2025 -->
 

--- a/schema/enriched.schema.json
+++ b/schema/enriched.schema.json
@@ -88,7 +88,7 @@
         "evidence_type": {
           "type": "string",
           "enum": ["partial", "complete"],
-          "description": "Whether this item evidences partial progress towards the recommendation being implemented, or complete implementation. Used to derive overall status: any 'complete' item → actioned; only 'partial' items → partial."
+          "description": "Whether this item evidences partial progress (e.g. accepted, steps underway) or complete implementation (e.g. law enacted, scheme operational). Used to derive overall status: any 'complete' approved item → actioned; only 'partial' approved items → partial."
         },
         "approved": {
           "type": "boolean",

--- a/tools/review_app/templates/index.html
+++ b/tools/review_app/templates/index.html
@@ -148,6 +148,17 @@
       font-size: 13px;
       margin-bottom: 4px;
     }
+    .ev-type-badge {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 2px 7px;
+      border-radius: 8px;
+      flex-shrink: 0;
+    }
+    .ev-type-partial  { background: #fef3c7; color: #92400e; }
+    .ev-type-complete { background: #d1fae5; color: #065f46; }
     .evidence-meta {
       font-size: 12px;
       color: #6b7280;


### PR DESCRIPTION
## Summary

Follows on from the inline editing PR (#141) and the `evidence_type` schema/data addition on `feature/evidence-ibi`.

- **Card view**: colour-coded badge on each evidence item — amber **partial**, green **complete**
- **Edit form**: `evidence_type` select so reviewers can promote an item from `partial` → `complete` when the evidence shows full implementation
- **`/edit` endpoint**: now accepts `evidence_type` as an editable field

## Why

A recommendation can have multiple evidence items at different stages. Tagging each item as partial or complete gives the reviewer a way to signal implementation status at the item level, rather than collapsing everything into a single rec-level status that one government-acceptance item would always pull down to partial.

## Test plan

- [x] Each card shows an amber "partial" or green "complete" badge next to the evidence title
- [ ] Opening Edit mode pre-fills the evidence type select with the current value
- [ ] Changing to "complete" and saving updates the badge on the card
- [ ] Verify `enriched_data.json` reflects the change on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)