### PR TITLE
Review app v2: two-phase review, bulk approval, approved_at, bug fixes

### DIFF
--- a/enriched_data.json
+++ b/enriched_data.json
@@ -11,7 +11,8 @@
         "date": null,
         "description": "NHS Constitution revised in 2013, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": "2026-04-28"
+        "approved_at": "2026-04-28",
+        "evidence_type": "complete"
       }
     ],
     "notes": "NHS Constitution was revised following the Mid Staffs inquiry. The publication history page confirms the 2013 revision."
@@ -26,7 +27,8 @@
         "date": null,
         "description": "NHS Constitution Handbook first published in 2015, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": "2026-04-28"
+        "approved_at": "2026-04-28",
+        "evidence_type": "complete"
       }
     ],
     "notes": "The NHS Constitution Handbook (supplement) was first published in 2015 following this recommendation."
@@ -41,7 +43,8 @@
         "date": "2025-04-03",
         "description": "Terrorism (Protection of Premises) Act 2025 (Martyn's Law) received Royal Assent on 3 April 2025, enacting the Protect Duty recommended by the inquiry.",
         "approved": true,
-        "approved_at": "2026-04-28"
+        "approved_at": "2026-04-28",
+        "evidence_type": "complete"
       }
     ],
     "notes": "MR4 called for a Protect Duty enacted by primary legislation. Following Figen Murray's campaign, the Terrorism (Protection of Premises) Act 2025 (Martyn's Law) achieved Royal Assent on 3 April 2025."

--- a/enriched_data.json
+++ b/enriched_data.json
@@ -11,7 +11,7 @@
         "date": null,
         "description": "NHS Constitution revised in 2013, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": null,
+        "approved_at": "2026-04-28",
         "submitted_by": null
       }
     ],
@@ -27,7 +27,7 @@
         "date": null,
         "description": "NHS Constitution Handbook first published in 2015, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": null,
+        "approved_at": "2026-04-28",
         "submitted_by": null
       }
     ],
@@ -43,7 +43,7 @@
         "date": "2025-04-03",
         "description": "Terrorism (Protection of Premises) Act 2025 (Martyn's Law) received Royal Assent on 3 April 2025, enacting the Protect Duty recommended by the inquiry.",
         "approved": true,
-        "approved_at": null,
+        "approved_at": "2026-04-28",
         "submitted_by": null
       }
     ],

--- a/enriched_data.json
+++ b/enriched_data.json
@@ -11,8 +11,7 @@
         "date": null,
         "description": "NHS Constitution revised in 2013, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": "2026-04-28",
-        "submitted_by": null
+        "approved_at": "2026-04-28"
       }
     ],
     "notes": "NHS Constitution was revised following the Mid Staffs inquiry. The publication history page confirms the 2013 revision."
@@ -27,8 +26,7 @@
         "date": null,
         "description": "NHS Constitution Handbook first published in 2015, following the inquiry published in February 2013.",
         "approved": true,
-        "approved_at": "2026-04-28",
-        "submitted_by": null
+        "approved_at": "2026-04-28"
       }
     ],
     "notes": "The NHS Constitution Handbook (supplement) was first published in 2015 following this recommendation."
@@ -43,8 +41,7 @@
         "date": "2025-04-03",
         "description": "Terrorism (Protection of Premises) Act 2025 (Martyn's Law) received Royal Assent on 3 April 2025, enacting the Protect Duty recommended by the inquiry.",
         "approved": true,
-        "approved_at": "2026-04-28",
-        "submitted_by": null
+        "approved_at": "2026-04-28"
       }
     ],
     "notes": "MR4 called for a Protect Duty enacted by primary legislation. Following Figen Murray's campaign, the Terrorism (Protection of Premises) Act 2025 (Martyn's Law) achieved Royal Assent on 3 April 2025."

--- a/index.html
+++ b/index.html
@@ -264,8 +264,18 @@
             const evidencedCount = Object.values(enrichedMap).filter(outcome =>
                 outcome.evidence && outcome.evidence.some(ev => ev.approved)
             ).length;
+            const fullyActionedCount = Object.values(enrichedMap).filter(o => o.evidence_status === 'actioned').length;
+            const partialCount = Object.values(enrichedMap).filter(o => o.evidence_status === 'partial').length;
             const badge = document.getElementById('evidenceCountBadge');
-            badge.textContent = `${evidencedCount} of ${processedData.length} recommendations have verified evidence`;
+            let badgeText = `${evidencedCount} of ${processedData.length} recommendations have verified evidence`;
+            if (fullyActionedCount > 0 && partialCount > 0) {
+                badgeText += ` (${fullyActionedCount} fully actioned, ${partialCount} partial)`;
+            } else if (fullyActionedCount > 0) {
+                badgeText += ` (${fullyActionedCount} fully actioned)`;
+            } else if (partialCount > 0) {
+                badgeText += ` (${partialCount} with partial evidence)`;
+            }
+            badge.textContent = badgeText;
             badge.style.display = 'block';
 
         // Store all data for filtering
@@ -320,15 +330,23 @@
                             outcomeCell.appendChild(document.createElement('br'));
                             outcomeCell.appendChild(document.createElement('br'));
                         }
+                        const titleLine = document.createElement('span');
                         if (ev.url) {
                             const evLink = document.createElement('a');
                             evLink.href = ev.url;
                             evLink.textContent = ev.title || 'View Evidence';
                             evLink.target = '_blank';
-                            outcomeCell.appendChild(evLink);
+                            titleLine.appendChild(evLink);
                         } else if (ev.title) {
-                            outcomeCell.appendChild(document.createTextNode(ev.title));
+                            titleLine.appendChild(document.createTextNode(ev.title));
                         }
+                        if (ev.evidence_type) {
+                            const typeBadge = document.createElement('span');
+                            typeBadge.className = `ev-badge ev-badge-${ev.evidence_type}`;
+                            typeBadge.textContent = ev.evidence_type;
+                            titleLine.appendChild(typeBadge);
+                        }
+                        outcomeCell.appendChild(titleLine);
                         if (ev.description) {
                             outcomeCell.appendChild(document.createElement('br'));
                             outcomeCell.appendChild(document.createTextNode(ev.description));

--- a/schema/enriched.schema.json
+++ b/schema/enriched.schema.json
@@ -91,11 +91,7 @@
         },
         "approved_at": {
           "type": ["string", "null"],
-          "description": "ISO 8601 datetime when this item was approved. Null until approved."
-        },
-        "submitted_by": {
-          "type": ["string", "null"],
-          "description": "GitHub username of the contributor, or 'public' for Google Form submissions, or null for maintainer-added items."
+          "description": "ISO 8601 date when this item was approved. Null until approved."
         }
       }
     }

--- a/schema/enriched.schema.json
+++ b/schema/enriched.schema.json
@@ -92,6 +92,11 @@
         "approved_at": {
           "type": ["string", "null"],
           "description": "ISO 8601 date when this item was approved. Null until approved."
+        },
+        "evidence_type": {
+          "type": ["string", "null"],
+          "enum": ["partial", "complete", null],
+          "description": "Whether this item evidences partial progress or full implementation. 'complete' = law enacted, scheme operational, policy in force. 'partial' = steps taken, not yet complete."
         }
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -292,3 +292,16 @@ tr:hover {
         display: none;
     }
 }
+
+/* Evidence type badges in the outcome column */
+.ev-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border-radius: 3px;
+    margin-left: 5px;
+    vertical-align: middle;
+    font-weight: 600;
+}
+.ev-badge-partial  { background: #fef3c7; color: #92400e; }
+.ev-badge-complete { background: #d1fae5; color: #065f46; }

--- a/tools/backfill_approved_at.py
+++ b/tools/backfill_approved_at.py
@@ -1,0 +1,54 @@
+"""
+Backfill approved_at timestamps
+================================
+Sets approved_at on all evidence items where approved:true but approved_at is null.
+
+Usage:
+    python tools/backfill_approved_at.py           # write changes
+    python tools/backfill_approved_at.py --dry-run # preview only, no writes
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+ENRICHED_PATH = REPO_ROOT / "enriched_data.json"
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+
+    with open(ENRICHED_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+
+    stamp = datetime.now(timezone.utc).isoformat()
+    found = []
+
+    for key, entry in data.items():
+        if key.startswith("_") or not isinstance(entry, dict):
+            continue
+        for i, item in enumerate(entry.get("evidence", [])):
+            if item.get("approved") and not item.get("approved_at"):
+                found.append((key, i, item.get("title", "(no title)")[:60]))
+                if not dry_run:
+                    item["approved_at"] = stamp
+
+    if not found:
+        print("Nothing to backfill — all approved items already have approved_at.")
+        return
+
+    for key, idx, title in found:
+        print(f"  {'[dry-run] ' if dry_run else ''}backfill: {key}  item {idx}: {title}")
+
+    if dry_run:
+        print(f"\n{len(found)} item(s) would be updated (dry run — no changes written).")
+    else:
+        with open(ENRICHED_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        print(f"\n{len(found)} item(s) updated with approved_at: {stamp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/backfill_approved_at.py
+++ b/tools/backfill_approved_at.py
@@ -23,7 +23,7 @@ def main():
     with open(ENRICHED_PATH, encoding="utf-8") as f:
         data = json.load(f)
 
-    stamp = datetime.now(timezone.utc).isoformat()
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     found = []
 
     for key, entry in data.items():

--- a/tools/review_app/README.md
+++ b/tools/review_app/README.md
@@ -39,28 +39,44 @@ python tools/review_app/app.py
 
 Open http://localhost:5000 in your browser.
 
-**Step 3 — Review each entry**
+The review is split into two phases:
 
-The app shows every `approved: false` evidence item grouped by inquiry. For each item you will see:
+**Phase 1 (http://localhost:5000/) — Approve individual evidence items**
+
+The app shows every `approved: false` evidence item grouped by inquiry and recommendation. For each item you will see:
 
 - The **recommendation text** (from `data.json`) — what the inquiry actually recommended
-- The **evidence title, source, date, and description** — what the submission claims as evidence
+- The **evidence title, URL, source type, evidence type badge, and description**
 
 For each item, choose one of:
 
 | Action | What it does |
 |---|---|
-| **Approve** | Sets `approved: true` — entry will appear publicly once the PR is merged |
+| **Approve** | Sets `approved: true` and stamps `approved_at` — item will appear publicly once merged |
 | **Reject** | Permanently removes the evidence item — use if the evidence does not support the recommendation |
-| **Set status** | Updates `evidence_status` for the recommendation (`actioned`, `partial`, `no_evidence_found`, `not_published`) |
+| **Edit** | Opens an inline form to correct the title, URL, date, source type, evidence type, or description |
+| **Approve all pending** | Bulk-approves every pending item in the current filter (with confirmation). Stamps `approved_at` on all. |
 
-> **Warning:** Reject is permanent and cannot be undone within the app. If you reject by mistake, re-run the original data import script or restore from git.
+> **Warning:** Reject is permanent and cannot be undone within the app. If you reject by mistake, restore from git or re-run the import script.
 
-Changes are written to `enriched_data.json` immediately on each action. You do not need to save manually.
+When Phase 1 is complete (no items remain), click the **"Review recommendation statuses →"** link that appears.
+
+**Phase 2 (http://localhost:5000/statuses) — Set recommendation status**
+
+Shows each recommendation that has at least one approved item. All approved items are visible together so you can assess the full picture before setting a status. Use the dropdown at the bottom of each card:
+
+| Status | When to use |
+|---|---|
+| **actioned** | At least one *complete* evidence item exists; the recommendation has been fully implemented (law enacted, scheme operational, policy in force) |
+| **partial** | Evidence shows progress but implementation is incomplete, paused, or only promised |
+| **no evidence found** | Researched; nothing found. Note the reason in the `notes` field |
+| **not published** | The recommendation itself was not made public |
+
+Setting a status does not auto-advance — scroll through all cards and set each one. Recommendations with no status are highlighted.
 
 **Step 4 — Commit and push**
 
-Once you have reviewed all entries:
+Once both phases are complete:
 
 ```bash
 git add enriched_data.json
@@ -71,6 +87,58 @@ git push
 **Step 5 — CI passes, merge the PR**
 
 The CI check (`Check all evidence items are approved before merging`) will now pass. The PR is ready to merge.
+
+---
+
+## Backfilling approved_at on existing items
+
+If you have items that were approved before `approved_at` stamping was implemented (they show `approved_at: null`), run the backfill script:
+
+```bash
+python tools/backfill_approved_at.py --dry-run   # preview
+python tools/backfill_approved_at.py             # write
+```
+
+---
+
+## Reviewer playbook
+
+### Phase 1 — What to check before approving
+
+**Does the URL work?** Open it. It should be publicly accessible, not behind a login.
+
+**Does the description match the source?** Read the actual page. The title and description should accurately describe what the source says — not what you hope it says.
+
+**Is this evidence for *this specific recommendation*?** A government "acceptance" document for the whole inquiry is not evidence for a specific recommendation being *implemented*. The source should show something happened as a direct result of this recommendation.
+
+**Source reliability (highest to lowest):**
+1. `legislation` — legislation.gov.uk (primary legislation is definitive)
+2. `official_report` — gov.uk or public body publications
+3. `parliamentary_record` — Hansard, committee reports
+4. `press_release` — government announcements (watch for over-claiming)
+5. `news_article` — useful supporting evidence; never the sole source for `complete`
+
+**What evidence_type to set:**
+
+| Type | Use when |
+|---|---|
+| `partial` | Government accepted the recommendation; consultation launched; steps announced; policy proposed but not in force |
+| `complete` | Law enacted; scheme operational; body established and functioning; policy in force |
+
+**Edit vs Reject:**
+- **Edit** if the core evidence is sound but the title or description is imprecise or too verbose.
+- **Reject** if the URL does not support the claim, the source is not about this recommendation, or the URL is broken.
+
+**Government position items (e.g. "Accepted in full — IBI Tracker"):** Keep these as `partial`. They confirm the recommendation was at minimum acknowledged, which is useful even if no further implementation evidence exists.
+
+### Phase 2 — Setting recommendation status
+
+Look at all approved items together before setting a status. The status is your overall judgement, not an automatic roll-up.
+
+- **actioned**: There is at least one `complete` item AND the recommendation's core ask (new law, new body, new system) is concretely delivered and in force.
+- **partial**: Some evidence of progress but the implementation is incomplete, paused, or only promised. Any mix of `partial`-type items only → use `partial`.
+- **no_evidence_found**: None of the approved items actually evidence this recommendation being addressed. Add a note explaining why.
+- **not_published**: Use only if the recommendation itself was never made public.
 
 ---
 

--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -51,7 +51,7 @@ def load_recommendations():
 
 
 def utc_now():
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
 @app.route("/")
@@ -258,7 +258,7 @@ def statuses():
             "rec_text": recs.get(key, "(recommendation text not found)"),
             "evidence_status": entry.get("evidence_status", ""),
             "notes": entry.get("notes", ""),
-            "items": approved_items,
+            "evidence_items": approved_items,
         })
 
     rec_cards.sort(key=lambda x: (x["inquiry"], x["key"]))

--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -10,12 +10,13 @@ Usage:
 
 Then open http://localhost:5000 in your browser.
 
-Entries with approved:false are shown for review. Approving an entry
-sets approved:true and saves immediately to enriched_data.json.
+Phase 1 (/):         Card-by-card approval queue for unapproved evidence items.
+Phase 2 (/statuses): Per-recommendation status review once items are approved.
 """
 
 import json
 import os
+from datetime import datetime, timezone
 from flask import Flask, jsonify, render_template, request
 
 app = Flask(__name__)
@@ -47,6 +48,10 @@ def load_recommendations():
             for i, rec in enumerate(inquiry.get("Recommendations", []), 1):
                 recs[f"{name}__{i}"] = rec["Recommendation"]
     return recs
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat()
 
 
 @app.route("/")
@@ -127,14 +132,36 @@ def approve():
         return jsonify({"ok": False, "error": "Index out of range"}), 400
 
     items[item_index]["approved"] = True
-
-    # If all items are now approved, update evidence_status if still partial
-    if all(i.get("approved") for i in items):
-        if entry.get("evidence_status") == "partial":
-            pass  # leave as partial — status reflects implementation, not review
+    items[item_index]["approved_at"] = utc_now()
 
     save_enriched(enriched)
     return jsonify({"ok": True})
+
+
+@app.route("/approve_all", methods=["POST"])
+def approve_all():
+    """Bulk-approve all unapproved items, optionally filtered to one inquiry."""
+    data = request.get_json()
+    inquiry_filter = (data.get("inquiry") or "").strip()
+
+    enriched = load_enriched()
+    stamped = utc_now()
+    count = 0
+
+    for key, entry in enriched.items():
+        if key.startswith("_") or not isinstance(entry, dict):
+            continue
+        inquiry_name = key.rsplit("__", 1)[0]
+        if inquiry_filter and inquiry_filter != inquiry_name:
+            continue
+        for item in entry.get("evidence", []):
+            if not item.get("approved"):
+                item["approved"] = True
+                item["approved_at"] = stamped
+                count += 1
+
+    save_enriched(enriched)
+    return jsonify({"ok": True, "count": count})
 
 
 @app.route("/reject", methods=["POST"])
@@ -163,6 +190,32 @@ def reject():
     return jsonify({"ok": True, "removed_title": removed.get("title", "")})
 
 
+@app.route("/edit", methods=["POST"])
+def edit():
+    """Update fields on a single evidence item."""
+    data = request.get_json()
+    key = data.get("key")
+    item_index = data.get("item_index")
+
+    enriched = load_enriched()
+    entry = enriched.get(key)
+    if not entry or item_index is None:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+
+    items = entry.get("evidence", [])
+    if not isinstance(item_index, int) or item_index < 0 or item_index >= len(items):
+        return jsonify({"ok": False, "error": "Index out of range"}), 400
+
+    item = items[item_index]
+    allowed_fields = {"title", "url", "date", "source_type", "description", "evidence_type"}
+    for field in allowed_fields:
+        if field in data:
+            item[field] = data[field]
+
+    save_enriched(enriched)
+    return jsonify({"ok": True})
+
+
 @app.route("/set_status", methods=["POST"])
 def set_status():
     """Update evidence_status for a key."""
@@ -180,6 +233,48 @@ def set_status():
     enriched[key]["evidence_status"] = status
     save_enriched(enriched)
     return jsonify({"ok": True})
+
+
+@app.route("/statuses")
+def statuses():
+    """Phase 2: per-recommendation status review."""
+    enriched = load_enriched()
+    recs = load_recommendations()
+    inquiry_filter = request.args.get("inquiry", "")
+
+    rec_cards = []
+    for key, entry in enriched.items():
+        if key.startswith("_") or not isinstance(entry, dict):
+            continue
+        inquiry_name = key.rsplit("__", 1)[0]
+        if inquiry_filter and inquiry_filter != inquiry_name:
+            continue
+        approved_items = [ev for ev in entry.get("evidence", []) if ev.get("approved")]
+        if not approved_items:
+            continue
+        rec_cards.append({
+            "key": key,
+            "inquiry": inquiry_name,
+            "rec_text": recs.get(key, "(recommendation text not found)"),
+            "evidence_status": entry.get("evidence_status", ""),
+            "notes": entry.get("notes", ""),
+            "items": approved_items,
+        })
+
+    rec_cards.sort(key=lambda x: (x["inquiry"], x["key"]))
+
+    all_inquiries = sorted(
+        {k.rsplit("__", 1)[0] for k in enriched if not k.startswith("_")}
+    )
+    needs_status = sum(1 for c in rec_cards if not c["evidence_status"])
+
+    return render_template(
+        "status_review.html",
+        rec_cards=rec_cards,
+        all_inquiries=all_inquiries,
+        inquiry_filter=inquiry_filter,
+        needs_status=needs_status,
+    )
 
 
 if __name__ == "__main__":

--- a/tools/review_app/templates/index.html
+++ b/tools/review_app/templates/index.html
@@ -190,13 +190,89 @@
     }
     .btn-reject:hover { background: #fee2e2; }
 
-    .status-select {
-      font-size: 12px;
-      padding: 4px 8px;
+    .ev-type-badge {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      margin-left: 6px;
+      vertical-align: middle;
+      font-weight: 600;
+    }
+    .ev-type-partial  { background: #fef3c7; color: #92400e; }
+    .ev-type-complete { background: #d1fae5; color: #065f46; }
+
+    .btn-approve-all {
+      padding: 5px 12px;
+      background: #f59e0b;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .btn-approve-all:hover { background: #d97706; }
+
+    .btn-edit {
+      padding: 5px 10px;
+      background: #fff;
+      color: #6b7280;
       border: 1px solid #d1d5db;
       border-radius: 4px;
-      margin-left: auto;
+      cursor: pointer;
+      font-size: 12px;
     }
+    .btn-edit:hover { background: #f3f4f6; }
+
+    .edit-form {
+      display: none;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 10px;
+      padding: 12px;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+    }
+    .edit-form.open { display: flex; }
+    .edit-form label {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #9ca3af;
+      margin-bottom: 2px;
+    }
+    .edit-form input, .edit-form select, .edit-form textarea {
+      width: 100%;
+      font-size: 13px;
+      padding: 6px 8px;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-family: inherit;
+    }
+    .edit-form textarea { min-height: 80px; resize: vertical; }
+    .edit-form-actions { display: flex; gap: 8px; margin-top: 4px; }
+    .btn-edit-save {
+      padding: 5px 14px;
+      background: #3b82f6;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .btn-edit-save:hover { background: #2563eb; }
+    .btn-edit-cancel {
+      padding: 5px 10px;
+      background: #f3f4f6;
+      color: #6b7280;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .btn-edit-cancel:hover { background: #e5e7eb; }
 
     .approved-label {
       font-size: 12px;
@@ -252,6 +328,11 @@
     <a href="/" style="font-size:13px;color:#6b7280;">Clear filter</a>
     {% endif %}
   </form>
+  {% if total_pending > 0 %}
+  <button class="btn-approve-all" onclick="approveAll('{{ inquiry_filter | e }}', {{ total_pending }})">
+    Approve all {{ total_pending }} pending{% if inquiry_filter %} ({{ inquiry_filter }}){% endif %}
+  </button>
+  {% endif %}
 </div>
 
 <main>
@@ -259,6 +340,9 @@
   <div class="empty-state">
     <h2>All done!</h2>
     <p>No pending evidence items{% if inquiry_filter %} for {{ inquiry_filter }}{% endif %}.</p>
+    <p style="margin-top:12px;font-size:14px;">
+      Next: <a href="/statuses" style="color:#3b82f6;">Review recommendation statuses &rarr;</a>
+    </p>
   </div>
 {% else %}
   {% set ns = namespace(current_inquiry='') %}
@@ -290,8 +374,14 @@
       {% endif %}
 
       {% for item_index, item in entry.pending_items %}
-      <div class="evidence-item" id="evitem-{{ entry.key | replace('__', '-') }}-{{ item_index }}">
-        <div class="evidence-title">{{ item.title }}</div>
+      {% set evid = entry.key | replace('__', '-') ~ '-' ~ item_index %}
+      <div class="evidence-item" id="evitem-{{ evid }}">
+        <div class="evidence-title">
+          {{ item.title }}
+          {% if item.evidence_type %}
+          <span class="ev-type-badge ev-type-{{ item.evidence_type }}">{{ item.evidence_type }}</span>
+          {% endif %}
+        </div>
         <div class="evidence-meta">
           {% if item.url %}
           <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url[:80] }}{% if item.url|length > 80 %}…{% endif %}</a> ·
@@ -305,13 +395,47 @@
         <div class="action-row">
           <button class="btn-approve" data-key="{{ entry.key }}" data-index="{{ item_index }}" onclick="approveItem(this.dataset.key, parseInt(this.dataset.index), this)">Approve</button>
           <button class="btn-reject" data-key="{{ entry.key }}" data-index="{{ item_index }}" onclick="rejectItem(this.dataset.key, parseInt(this.dataset.index), this)">Reject</button>
-          <select class="status-select" data-key="{{ entry.key }}" onchange="setStatus(this.dataset.key, this.value)" title="Update evidence_status for this recommendation">
-            <option value="">— set status —</option>
-            <option value="actioned" {% if entry.evidence_status == 'actioned' %}selected{% endif %}>actioned</option>
-            <option value="partial" {% if entry.evidence_status == 'partial' %}selected{% endif %}>partial</option>
-            <option value="no_evidence_found" {% if entry.evidence_status == 'no_evidence_found' %}selected{% endif %}>no_evidence_found</option>
-            <option value="not_published" {% if entry.evidence_status == 'not_published' %}selected{% endif %}>not_published</option>
-          </select>
+          <button class="btn-edit" onclick="toggleEditForm('{{ evid }}')">Edit</button>
+        </div>
+        <div class="edit-form" id="editform-{{ evid }}">
+          <div>
+            <label>Title</label>
+            <input type="text" id="edit-title-{{ evid }}" value="{{ item.title | e }}">
+          </div>
+          <div>
+            <label>URL</label>
+            <input type="url" id="edit-url-{{ evid }}" value="{{ item.url | e }}">
+          </div>
+          <div style="display:flex;gap:8px;">
+            <div style="flex:1">
+              <label>Date (YYYY-MM-DD)</label>
+              <input type="text" id="edit-date-{{ evid }}" value="{{ item.date or '' }}">
+            </div>
+            <div style="flex:1">
+              <label>Source type</label>
+              <select id="edit-source-{{ evid }}">
+                {% for st in ['official_report','legislation','press_release','parliamentary_record','news_article'] %}
+                <option value="{{ st }}" {% if item.source_type == st %}selected{% endif %}>{{ st | replace('_',' ') }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div style="flex:1">
+              <label>Evidence type</label>
+              <select id="edit-evtype-{{ evid }}">
+                <option value="" {% if not item.evidence_type %}selected{% endif %}>— unset —</option>
+                <option value="partial" {% if item.evidence_type == 'partial' %}selected{% endif %}>partial</option>
+                <option value="complete" {% if item.evidence_type == 'complete' %}selected{% endif %}>complete</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label>Description</label>
+            <textarea id="edit-desc-{{ evid }}">{{ item.description | e }}</textarea>
+          </div>
+          <div class="edit-form-actions">
+            <button class="btn-edit-save" onclick="saveEdit('{{ entry.key }}', {{ item_index }}, '{{ evid }}')">Save</button>
+            <button class="btn-edit-cancel" onclick="toggleEditForm('{{ evid }}')">Cancel</button>
+          </div>
         </div>
       </div>
       {% endfor %}
@@ -384,17 +508,65 @@ function rejectItem(key, itemIndex, btn) {
   });
 }
 
-function setStatus(key, status) {
-  if (!status) return;
-  fetch('/set_status', {
+function approveAll(inquiry, count) {
+  const label = inquiry ? `all ${count} pending items for "${inquiry}"` : `all ${count} pending items`;
+  if (!confirm(`Approve ${label}? This sets approved:true on every pending item and cannot be undone.`)) return;
+  fetch('/approve_all', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({key, status})
+    body: JSON.stringify({inquiry})
   })
   .then(r => r.json())
   .then(data => {
-    if (data.ok) showToast('Status updated to: ' + status);
-    else showToast('Error: ' + (data.error || 'unknown'));
+    if (data.ok) {
+      showToast(`Approved ${data.count} item(s)`, 3000);
+      setTimeout(() => window.location.reload(), 1000);
+    } else {
+      showToast('Error: ' + (data.error || 'unknown'));
+    }
+  });
+}
+
+function toggleEditForm(evid) {
+  const form = document.getElementById('editform-' + evid);
+  form.classList.toggle('open');
+}
+
+function saveEdit(key, itemIndex, evid) {
+  const payload = {
+    key,
+    item_index: itemIndex,
+    title:       document.getElementById('edit-title-'  + evid).value.trim(),
+    url:         document.getElementById('edit-url-'    + evid).value.trim(),
+    date:        document.getElementById('edit-date-'   + evid).value.trim(),
+    source_type: document.getElementById('edit-source-' + evid).value,
+    evidence_type: document.getElementById('edit-evtype-' + evid).value || null,
+    description: document.getElementById('edit-desc-'  + evid).value.trim(),
+  };
+  fetch('/edit', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.ok) {
+      showToast('Saved');
+      // Update visible title and badge without full reload
+      const el = document.getElementById('evitem-' + evid);
+      if (el) {
+        const titleEl = el.querySelector('.evidence-title');
+        const badge = payload.evidence_type
+          ? `<span class="ev-type-badge ev-type-${payload.evidence_type}">${payload.evidence_type}</span>`
+          : '';
+        titleEl.innerHTML = payload.title + (badge ? ' ' + badge : '');
+        el.querySelector('.evidence-desc').textContent = payload.description;
+        el.querySelector('.evidence-meta').childNodes[0].textContent = '';
+      }
+      document.getElementById('editform-' + evid).classList.remove('open');
+    } else {
+      showToast('Error: ' + (data.error || 'unknown'));
+    }
   });
 }
 

--- a/tools/review_app/templates/status_review.html
+++ b/tools/review_app/templates/status_review.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Status Review — UK Inquiry Dashboard</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      background: #f5f5f5;
+      color: #222;
+    }
+
+    header {
+      background: #1a1a2e;
+      color: #fff;
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    header h1 { font-size: 16px; font-weight: 600; }
+    .phase-label {
+      font-size: 12px;
+      background: #3b82f6;
+      padding: 2px 10px;
+      border-radius: 10px;
+      margin-left: 10px;
+    }
+    .counts { font-size: 13px; opacity: 0.8; }
+
+    .filter-bar {
+      background: #fff;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 10px 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .filter-bar label { font-size: 13px; color: #555; }
+    .filter-bar select {
+      padding: 5px 10px;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+    .filter-bar button {
+      padding: 5px 12px;
+      background: #3b82f6;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .filter-bar button:hover { background: #2563eb; }
+    .phase-nav {
+      margin-left: auto;
+      font-size: 13px;
+      color: #6b7280;
+    }
+    .phase-nav a { color: #3b82f6; text-decoration: none; }
+    .phase-nav a:hover { text-decoration: underline; }
+
+    main { max-width: 960px; margin: 0 auto; padding: 24px 16px; }
+
+    .inquiry-group { margin-bottom: 32px; }
+    .inquiry-group h2 {
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+      border-bottom: 2px solid #1a1a2e;
+      padding-bottom: 6px;
+      margin-bottom: 16px;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      overflow: hidden;
+    }
+    .card.status-set { border-left: 4px solid #10b981; }
+    .card.status-unset { border-left: 4px solid #fbbf24; }
+
+    .card-header {
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .card-key {
+      font-size: 12px;
+      font-family: monospace;
+      color: #6b7280;
+    }
+    .status-badge {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 12px;
+      white-space: nowrap;
+    }
+    .status-actioned         { background: #d1fae5; color: #065f46; }
+    .status-partial          { background: #fef3c7; color: #92400e; }
+    .status-no_evidence_found { background: #fee2e2; color: #991b1b; }
+    .status-not_published    { background: #f3f4f6; color: #374151; }
+    .status-unset-badge      { background: #fef3c7; color: #92400e; font-style: italic; }
+
+    .rec-text {
+      padding: 12px 16px;
+      font-size: 13px;
+      color: #374151;
+      border-bottom: 1px solid #f0f0f0;
+      font-style: italic;
+      max-height: 80px;
+      overflow: hidden;
+      position: relative;
+    }
+    .rec-text.expanded { max-height: none; }
+    .expand-btn {
+      background: none;
+      border: none;
+      color: #3b82f6;
+      cursor: pointer;
+      font-size: 12px;
+      padding: 0;
+      display: block;
+      margin-top: 4px;
+    }
+
+    .notes {
+      padding: 8px 16px;
+      font-size: 12px;
+      color: #6b7280;
+      background: #fafafa;
+      border-bottom: 1px solid #f0f0f0;
+    }
+
+    .evidence-list { padding: 0; }
+
+    .evidence-item {
+      padding: 12px 16px;
+      border-bottom: 1px solid #f0f0f0;
+    }
+    .evidence-item:last-of-type { border-bottom: none; }
+
+    .evidence-title {
+      font-weight: 600;
+      font-size: 13px;
+      margin-bottom: 3px;
+    }
+    .evidence-title a { color: #1d4ed8; text-decoration: none; }
+    .evidence-title a:hover { text-decoration: underline; }
+
+    .ev-type-badge {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      margin-left: 6px;
+      vertical-align: middle;
+      font-weight: 600;
+    }
+    .ev-type-partial  { background: #fef3c7; color: #92400e; }
+    .ev-type-complete { background: #d1fae5; color: #065f46; }
+
+    .evidence-meta {
+      font-size: 12px;
+      color: #9ca3af;
+      margin-bottom: 4px;
+    }
+    .evidence-desc {
+      font-size: 13px;
+      color: #374151;
+    }
+
+    .status-row {
+      padding: 12px 16px;
+      background: #f9fafb;
+      border-top: 1px solid #e5e7eb;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .status-row label { font-size: 13px; color: #374151; font-weight: 600; }
+    .status-select {
+      font-size: 13px;
+      padding: 5px 10px;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+    }
+
+    .guide {
+      font-size: 12px;
+      color: #9ca3af;
+      line-height: 1.6;
+    }
+    .guide details summary {
+      cursor: pointer;
+      color: #6b7280;
+      font-size: 12px;
+      user-select: none;
+    }
+    .guide details[open] { margin-top: 4px; }
+    .guide ul { padding-left: 16px; margin-top: 4px; }
+    .guide li { margin-bottom: 2px; }
+
+    .empty-state {
+      text-align: center;
+      padding: 64px 24px;
+      color: #6b7280;
+    }
+    .empty-state h2 { font-size: 20px; margin-bottom: 8px; color: #374151; }
+
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      background: #1a1a2e;
+      color: #fff;
+      padding: 10px 20px;
+      border-radius: 6px;
+      font-size: 13px;
+      opacity: 0;
+      transition: opacity 0.2s;
+      pointer-events: none;
+      z-index: 999;
+    }
+    .toast.show { opacity: 1; }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Status Review <span class="phase-label">Phase 2</span></h1>
+  <div class="counts">
+    {% if needs_status > 0 %}
+    <span style="color:#fbbf24;font-weight:600;">{{ needs_status }} without status</span>
+    {% else %}
+    <span style="color:#6ee7b7;font-weight:600;">All statuses set</span>
+    {% endif %}
+  </div>
+</header>
+
+<div class="filter-bar">
+  <form method="get" action="/statuses" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+    <label for="inquiry-select">Filter by inquiry:</label>
+    <select id="inquiry-select" name="inquiry">
+      <option value="">All inquiries</option>
+      {% for inq in all_inquiries %}
+      <option value="{{ inq }}" {% if inq == inquiry_filter %}selected{% endif %}>{{ inq }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">Apply</button>
+    {% if inquiry_filter %}
+    <a href="/statuses" style="font-size:13px;color:#6b7280;">Clear filter</a>
+    {% endif %}
+  </form>
+  <span class="phase-nav">&larr; <a href="/">Back to item approval (Phase 1)</a></span>
+</div>
+
+<main>
+{% if not rec_cards %}
+  <div class="empty-state">
+    <h2>Nothing to review</h2>
+    <p>No recommendations with approved evidence{% if inquiry_filter %} for {{ inquiry_filter }}{% endif %}.</p>
+    <p style="margin-top:12px;">
+      <a href="/" style="color:#3b82f6;">Go to item approval &rarr;</a>
+    </p>
+  </div>
+{% else %}
+  {% set ns = namespace(current_inquiry='') %}
+  {% for card in rec_cards %}
+    {% if card.inquiry != ns.current_inquiry %}
+      {% if ns.current_inquiry != '' %}</div>{% endif %}
+      {% set ns.current_inquiry = card.inquiry %}
+      <div class="inquiry-group">
+      <h2>{{ card.inquiry }}</h2>
+    {% endif %}
+
+    <div class="card {% if card.evidence_status %}status-set{% else %}status-unset{% endif %}"
+         id="card-{{ card.key | replace('__', '-') }}">
+
+      <div class="card-header">
+        <div class="card-key">{{ card.key }}</div>
+        {% if card.evidence_status %}
+        <span class="status-badge status-{{ card.evidence_status }}">{{ card.evidence_status }}</span>
+        {% else %}
+        <span class="status-badge status-unset-badge">no status</span>
+        {% endif %}
+      </div>
+
+      <div class="rec-text" id="rectext-{{ loop.index }}">
+        {{ card.rec_text }}
+        <button class="expand-btn" onclick="toggleExpand({{ loop.index }})">show more</button>
+      </div>
+
+      {% if card.notes %}
+      <div class="notes">{{ card.notes }}</div>
+      {% endif %}
+
+      <div class="evidence-list">
+        {% for item in card.items %}
+        <div class="evidence-item">
+          <div class="evidence-title">
+            {% if item.url %}
+            <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>
+            {% else %}
+            {{ item.title }}
+            {% endif %}
+            {% if item.evidence_type %}
+            <span class="ev-type-badge ev-type-{{ item.evidence_type }}">{{ item.evidence_type }}</span>
+            {% endif %}
+          </div>
+          <div class="evidence-meta">
+            {{ item.source_type | replace('_', ' ') }} · {{ item.date or 'no date' }}
+          </div>
+          {% if item.description %}
+          <div class="evidence-desc">{{ item.description }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+
+      <div class="status-row">
+        <label for="status-{{ card.key | replace('__', '-') }}">Recommendation status:</label>
+        <select id="status-{{ card.key | replace('__', '-') }}"
+                class="status-select"
+                data-key="{{ card.key }}"
+                onchange="setStatus(this.dataset.key, this.value, this)">
+          <option value="">— set status —</option>
+          <option value="actioned"          {% if card.evidence_status == 'actioned' %}selected{% endif %}>actioned — fully implemented</option>
+          <option value="partial"           {% if card.evidence_status == 'partial' %}selected{% endif %}>partial — progress made, not complete</option>
+          <option value="no_evidence_found" {% if card.evidence_status == 'no_evidence_found' %}selected{% endif %}>no evidence found</option>
+          <option value="not_published"     {% if card.evidence_status == 'not_published' %}selected{% endif %}>not published</option>
+        </select>
+        <div class="guide">
+          <details>
+            <summary>Decision guide</summary>
+            <ul>
+              <li><strong>actioned</strong> — at least one <em>complete</em> evidence item; recommendation fully implemented (law enacted, scheme operational)</li>
+              <li><strong>partial</strong> — evidence shows progress but implementation is incomplete, paused, or only promised</li>
+              <li><strong>no evidence found</strong> — researched; nothing found (note why in the notes field)</li>
+              <li><strong>not published</strong> — recommendation was not made public</li>
+            </ul>
+          </details>
+        </div>
+      </div>
+
+    </div>
+
+  {% endfor %}
+  {% if ns.current_inquiry != '' %}</div>{% endif %}
+{% endif %}
+</main>
+
+<div class="toast" id="toast"></div>
+
+<script>
+function showToast(msg, duration=2000) {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.classList.add('show');
+  setTimeout(() => t.classList.remove('show'), duration);
+}
+
+function setStatus(key, status, selectEl) {
+  if (!status) return;
+  fetch('/set_status', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({key, status})
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.ok) {
+      showToast('Status: ' + status);
+      // Update the card border and badge
+      const cardId = 'card-' + key.replace('__', '-');
+      const card = document.getElementById(cardId);
+      if (card) {
+        card.classList.remove('status-set', 'status-unset');
+        card.classList.add('status-set');
+        const badge = card.querySelector('.status-badge');
+        if (badge) {
+          badge.className = 'status-badge status-' + status;
+          badge.textContent = status;
+        }
+      }
+    } else {
+      showToast('Error: ' + (data.error || 'unknown'));
+      if (selectEl) selectEl.value = '';
+    }
+  });
+}
+
+function toggleExpand(idx) {
+  const el = document.getElementById('rectext-' + idx);
+  const btn = el.querySelector('.expand-btn');
+  if (el.classList.toggle('expanded')) {
+    btn.textContent = 'show less';
+  } else {
+    btn.textContent = 'show more';
+  }
+}
+</script>
+</body>
+</html>

--- a/tools/review_app/templates/status_review.html
+++ b/tools/review_app/templates/status_review.html
@@ -303,17 +303,15 @@
         {% endif %}
       </div>
 
-      <div class="rec-text" id="rectext-{{ loop.index }}">
-        {{ card.rec_text }}
-        <button class="expand-btn" onclick="toggleExpand({{ loop.index }})">show more</button>
-      </div>
+      <div class="rec-text" id="rectext-{{ loop.index }}">{{ card.rec_text }}</div>
+      <button class="expand-btn" id="expbtn-{{ loop.index }}" onclick="toggleExpand({{ loop.index }})" style="display:none;padding:2px 16px 8px;">show more</button>
 
       {% if card.notes %}
       <div class="notes">{{ card.notes }}</div>
       {% endif %}
 
       <div class="evidence-list">
-        {% for item in card.items %}
+        {% for item in card.evidence_items %}
         <div class="evidence-item">
           <div class="evidence-title">
             {% if item.url %}
@@ -409,13 +407,24 @@ function setStatus(key, status, selectEl) {
 
 function toggleExpand(idx) {
   const el = document.getElementById('rectext-' + idx);
-  const btn = el.querySelector('.expand-btn');
+  const btn = document.getElementById('expbtn-' + idx);
   if (el.classList.toggle('expanded')) {
     btn.textContent = 'show less';
   } else {
     btn.textContent = 'show more';
   }
 }
+
+// Show expand buttons only where text is actually clipped
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.rec-text').forEach(function (el) {
+    if (el.scrollHeight > el.clientHeight) {
+      const idx = el.id.replace('rectext-', '');
+      const btn = document.getElementById('expbtn-' + idx);
+      if (btn) btn.style.display = 'block';
+    }
+  });
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Two-phase review flow**: Phase 1 (\`/\`) = individual item approval; Phase 2 (\`/statuses\`) = set \`evidence_status\` per recommendation after seeing all approved items together. Status dropdown removed from Phase 1 — no more rec-level judgement while still reading items.
- **\`approved_at\` fix**: \`/approve\` now stamps \`approved_at\` (YYYY-MM-DD) on each approval. Includes \`tools/backfill_approved_at.py\` to backfill existing items (\`--dry-run\` supported).
- **Bulk approval**: "Approve all pending" button with confirmation; \`/approve_all\` endpoint with optional inquiry filter. Both stamp \`approved_at\`.
- **\`evidence_type\` badges**: partial/complete badges per approved item in the dashboard outcome cell and Phase 2 status cards. Existing items set to \`complete\`.
- **Count badge breakdown**: Dashboard header shows "X fully actioned, Y partial" split.
- **Reviewer playbook**: \`tools/review_app/README.md\` extended with full two-phase workflow and decision criteria.
- **Remove \`submitted_by\`**: Field dropped from schema and all data — git history and PR authorship is the audit trail.
- **Bug fixes**: \`/statuses\` 500 error (Jinja2 \`card.items\` name collision); "show more" button hidden inside \`overflow:hidden\` container; \`approved_at\` trimmed to date-only (YYYY-MM-DD).

## Test plan

- [x] \`python tools/review_app/app.py\` — Phase 1 loads
- [x] Approve one item → \`enriched_data.json\` has \`approved_at: YYYY-MM-DD\`
- [ ] "Approve all pending" → all items approved + \`approved_at\` stamped
- [x] Phase 1 done state → link to \`/statuses\`
- [x] \`/statuses\` loads; set a status → badge updates, saves to file
- [x] "show more" visible and clickable on long recommendation texts
- [x] \`python tools/backfill_approved_at.py --dry-run\` lists null entries
- [x] \`index.html\` shows evidence_type badges (green = complete, amber = partial) and actioned/partial count split

🤖 Generated with [Claude Code](https://claude.com/claude-code)