### PR TITLE
Phase 2: send evidence items back to Phase 1 for re-review

### DIFF
--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -138,6 +138,29 @@ def approve():
     return jsonify({"ok": True})
 
 
+@app.route("/unapprove", methods=["POST"])
+def unapprove():
+    """Send an approved item back to Phase 1 by setting approved: false."""
+    data = request.get_json()
+    key = data.get("key")
+    item_index = data.get("item_index")
+
+    enriched = load_enriched()
+    entry = enriched.get(key)
+    if not entry or item_index is None:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+
+    items = entry.get("evidence", [])
+    if not isinstance(item_index, int) or item_index < 0 or item_index >= len(items):
+        return jsonify({"ok": False, "error": "Index out of range"}), 400
+
+    items[item_index]["approved"] = False
+    items[item_index]["approved_at"] = None
+
+    save_enriched(enriched)
+    return jsonify({"ok": True})
+
+
 @app.route("/approve_all", methods=["POST"])
 def approve_all():
     """Bulk-approve all unapproved items, optionally filtered to one inquiry."""
@@ -249,7 +272,11 @@ def statuses():
         inquiry_name = key.rsplit("__", 1)[0]
         if inquiry_filter and inquiry_filter != inquiry_name:
             continue
-        approved_items = [ev for ev in entry.get("evidence", []) if ev.get("approved")]
+        approved_items = [
+            {"_idx": i, **ev}
+            for i, ev in enumerate(entry.get("evidence", []))
+            if ev.get("approved")
+        ]
         if not approved_items:
             continue
         rec_cards.append({

--- a/tools/review_app/templates/status_review.html
+++ b/tools/review_app/templates/status_review.html
@@ -156,6 +156,18 @@
     }
     .evidence-item:last-of-type { border-bottom: none; }
 
+    .btn-send-back {
+      margin-top: 8px;
+      background: none;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-size: 11px;
+      color: #6b7280;
+      cursor: pointer;
+    }
+    .btn-send-back:hover { border-color: #9ca3af; color: #374151; }
+
     .evidence-title {
       font-weight: 600;
       font-size: 13px;
@@ -312,7 +324,7 @@
 
       <div class="evidence-list">
         {% for item in card.evidence_items %}
-        <div class="evidence-item">
+        <div class="evidence-item" id="evitem-{{ card.key | replace('__', '-') }}-{{ item._idx }}">
           <div class="evidence-title">
             {% if item.url %}
             <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>
@@ -329,6 +341,12 @@
           {% if item.description %}
           <div class="evidence-desc">{{ item.description }}</div>
           {% endif %}
+          <button class="btn-send-back"
+                  data-key="{{ card.key }}"
+                  data-index="{{ item._idx }}"
+                  onclick="sendBack(this.dataset.key, parseInt(this.dataset.index), this)">
+            ↩ Send back to Phase 1
+          </button>
         </div>
         {% endfor %}
       </div>
@@ -373,6 +391,32 @@ function showToast(msg, duration=2000) {
   t.textContent = msg;
   t.classList.add('show');
   setTimeout(() => t.classList.remove('show'), duration);
+}
+
+function sendBack(key, itemIndex, btn) {
+  if (!confirm('Send this item back to Phase 1 for re-review? It will be marked unapproved.')) return;
+  btn.disabled = true;
+  fetch('/unapprove', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({key, item_index: itemIndex})
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.ok) {
+      const itemEl = document.getElementById(`evitem-${key.replace('__', '-')}-${itemIndex}`);
+      if (itemEl) itemEl.remove();
+      // If the card now has no evidence items, remove the whole card
+      const cardEl = document.getElementById(`card-${key.replace('__', '-')}`);
+      if (cardEl && cardEl.querySelectorAll('.evidence-item').length === 0) {
+        cardEl.remove();
+      }
+      showToast('Sent back to Phase 1');
+    } else {
+      btn.disabled = false;
+      showToast('Error: ' + (data.error || 'unknown'));
+    }
+  });
 }
 
 function setStatus(key, status, selectEl) {


### PR DESCRIPTION
## Summary
- Each evidence item in Phase 2 now has a **Send back to Phase 1** button
- Clicking it confirms, then posts to the new `/unapprove` endpoint which sets `approved: false` and `approved_at: null`
- Item is removed from the Phase 2 card immediately; if it was the last item on the card, the card is removed too
- Item reappears in Phase 1's approval queue on next page load

## Test plan
- [x] Start review app, complete Phase 1, open Phase 2
- [x] Click "Send back to Phase 1" on an item — confirm dialog appears
- [x] Item disappears from Phase 2 card
- [x] Go to Phase 1 — item reappears in the queue
- [x] Send back last item on a card — whole card disappears from Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)