### PR TITLE
Add outcome status visualizations to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,11 @@
                 Only 4 of 20 inquiries (10.3% of recommendations) have been researched so far.
                 Grey = <strong>not yet researched</strong> — does not imply government inaction.
             </div>
-            <div id="outcomeLegend" style="display:flex;flex-wrap:wrap;gap:12px;margin:12px 0 20px 0;font-size:13px;"></div>
-            <h3 style="color:#374151;margin-bottom:8px;">Outcomes by Department</h3>
+            <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:4px;">
+                <div id="outcomeLegend" style="display:flex;flex-wrap:wrap;gap:12px;font-size:13px;flex:1;"></div>
+                <button id="outcomeToggleBtn" class="chart-toggle-btn" style="flex-shrink:0;">Show by Change Type</button>
+            </div>
+            <h3 style="color:#374151;margin:16px 0 8px 0;">Outcomes by Department</h3>
             <div id="outcomeBarChart" style="overflow-x:auto;margin-bottom:32px;"></div>
             <h3 style="color:#374151;margin-bottom:8px;">Outcomes by Action Category</h3>
             <div id="outcomeCategoryChart" style="overflow-x:auto;margin-bottom:16px;"></div>
@@ -749,9 +752,21 @@
             createZoomableSunburst(actionsData, "#actionsSunburstChart");
             // Create outcome visualizations
             const deptStats = computeOutcomeStats(processedData);
-            createOutcomeLegend();
-            createOutcomeBarChart(deptStats);
-            createOutcomeCategoryChart(processedData);
+            let outcomeMode = 'outcome';
+            createOutcomeLegend(outcomeMode);
+            createOutcomeBarChart(deptStats, processedData, outcomeMode);
+            createOutcomeCategoryChart(processedData, outcomeMode);
+
+            const outcomeToggleBtn = document.getElementById('outcomeToggleBtn');
+            if (outcomeToggleBtn) {
+                outcomeToggleBtn.addEventListener('click', function() {
+                    outcomeMode = outcomeMode === 'outcome' ? 'changetype' : 'outcome';
+                    this.textContent = outcomeMode === 'outcome' ? 'Show by Change Type' : 'Show by Outcome Status';
+                    createOutcomeLegend(outcomeMode);
+                    createOutcomeBarChart(deptStats, processedData, outcomeMode);
+                    createOutcomeCategoryChart(processedData, outcomeMode);
+                });
+            }
             console.log("All charts created successfully");
         })
         .catch(error => {
@@ -783,16 +798,26 @@
         })).sort((a, b) => b.outstanding - a.outstanding);
     }
 
-    function createOutcomeLegend() {
+    function createOutcomeLegend(mode) {
         const container = document.getElementById('outcomeLegend');
         if (!container) return;
-        const items = [
-            { label: 'Actioned',               color: '#10b981' },
-            { label: 'Partial evidence',        color: '#f59e0b' },
-            { label: 'No evidence found',       color: '#ef4444' },
-            { label: 'Not published',           color: '#9ca3af' },
-            { label: 'Research pending',        color: '#d1d5db', border: '#9ca3af' },
-        ];
+        container.innerHTML = '';
+        const items = mode === 'changetype'
+            ? [
+                { label: 'New',       color: '#2ca02c' },
+                { label: 'More',      color: '#1f77b4' },
+                { label: 'Different', color: '#9467bd' },
+                { label: 'Less',      color: '#ff7f0e' },
+                { label: 'Cease',     color: '#d62728' },
+                { label: 'None',      color: '#878c8f' },
+              ]
+            : [
+                { label: 'Actioned',            color: '#10b981' },
+                { label: 'Partial evidence',    color: '#f59e0b' },
+                { label: 'No evidence found',   color: '#ef4444' },
+                { label: 'Not published',       color: '#9ca3af' },
+                { label: 'Research pending',    color: '#d1d5db', border: '#9ca3af' },
+              ];
         items.forEach(item => {
             const span = document.createElement('span');
             span.style.cssText = 'display:inline-flex;align-items:center;gap:6px;';
@@ -801,19 +826,18 @@
         });
     }
 
-    function createOutcomeBarChart(deptStats) {
-        const container = document.getElementById('outcomeBarChart');
+    function buildHorizontalStackedBar(containerId, rowData, labelKey, stackKeys, colorMap, labelMap, annotationFn, annotationNote) {
+        d3.select(containerId).selectAll('*').remove();
+        const container = document.getElementById(containerId.replace('#',''));
         if (!container) return;
-        d3.select('#outcomeBarChart').selectAll('*').remove();
 
         const isMobile = window.innerWidth < 768;
         const margin = { top: 24, right: isMobile ? 90 : 150, bottom: 30, left: isMobile ? 150 : 210 };
-        const containerWidth = container.offsetWidth || 800;
-        const width = Math.max(containerWidth - margin.left - margin.right, 200);
+        const width = Math.max((container.offsetWidth || 800) - margin.left - margin.right, 200);
         const barHeight = 26;
-        const height = deptStats.length * (barHeight + 10);
+        const height = rowData.length * (barHeight + 10);
 
-        const svg = d3.select('#outcomeBarChart')
+        const svg = d3.select(containerId)
             .append('svg')
             .attr('viewBox', `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
             .attr('width', '100%')
@@ -822,154 +846,96 @@
             .append('g')
             .attr('transform', `translate(${margin.left},${margin.top})`);
 
-        svg.append('text')
-            .attr('x', 0).attr('y', -8)
-            .attr('font-size', '11px').attr('fill', '#9ca3af')
-            .text('Grey = not yet researched (does not mean unactioned)');
+        if (annotationNote) {
+            svg.append('text').attr('x', 0).attr('y', -8)
+                .attr('font-size', '11px').attr('fill', '#9ca3af').text(annotationNote);
+        }
 
-        const maxTotal = d3.max(deptStats, d => d.total);
+        const maxTotal = d3.max(rowData, d => d.total);
         const x = d3.scaleLinear().domain([0, maxTotal]).range([0, width]);
-        const y = d3.scaleBand()
-            .domain(deptStats.map(d => d.department))
-            .range([0, height])
-            .padding(0.2);
+        const y = d3.scaleBand().domain(rowData.map(d => d[labelKey])).range([0, height]).padding(0.2);
 
-        const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
-        const statusLabels = {
-            actioned: 'Actioned', partial: 'Partial',
-            no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending'
-        };
-
-        const stack = d3.stack().keys(statusKeys)(deptStats);
-        stack.forEach(layer => {
-            svg.selectAll(`.bar-seg-${layer.key}`)
-                .data(layer)
-                .join('rect')
+        d3.stack().keys(stackKeys)(rowData).forEach(layer => {
+            svg.selectAll(null).data(layer).join('rect')
                 .attr('x', d => x(d[0]))
-                .attr('y', d => y(d.data.department))
+                .attr('y', d => y(d.data[labelKey]))
                 .attr('width', d => Math.max(0, x(d[1]) - x(d[0])))
                 .attr('height', y.bandwidth())
-                .attr('fill', outcomeStatusColor[layer.key])
+                .attr('fill', colorMap[layer.key])
                 .append('title')
-                .text(d => `${d.data.department}\n${statusLabels[layer.key]}: ${d.data[layer.key]} (${Math.round(d.data[layer.key] / d.data.total * 100)}%)`);
+                .text(d => `${d.data[labelKey]}\n${labelMap[layer.key]}: ${d.data[layer.key]} (${Math.round(d.data[layer.key] / d.data.total * 100)}%)`);
         });
 
-        svg.append('g')
-            .call(d3.axisLeft(y).tickSize(0))
+        svg.append('g').call(d3.axisLeft(y).tickSize(0))
             .call(g => g.select('.domain').remove())
-            .selectAll('text')
-            .attr('font-size', isMobile ? '10px' : '12px')
-            .attr('fill', '#374151');
+            .selectAll('text').attr('font-size', isMobile ? '10px' : '12px').attr('fill', '#374151');
 
-        svg.append('g')
-            .attr('transform', `translate(0,${height})`)
-            .call(d3.axisBottom(x).ticks(5))
-            .call(g => g.select('.domain').remove());
+        svg.append('g').attr('transform', `translate(0,${height})`)
+            .call(d3.axisBottom(x).ticks(5)).call(g => g.select('.domain').remove());
 
-        deptStats.forEach(d => {
-            svg.append('text')
-                .attr('x', x(d.total) + 6)
-                .attr('y', y(d.department) + y.bandwidth() / 2 + 4)
-                .attr('font-size', '11px')
-                .attr('fill', '#9ca3af')
-                .text(d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched');
-        });
+        if (annotationFn) {
+            rowData.forEach(d => {
+                const label = annotationFn(d);
+                if (label) {
+                    svg.append('text')
+                        .attr('x', x(d.total) + 6)
+                        .attr('y', y(d[labelKey]) + y.bandwidth() / 2 + 4)
+                        .attr('font-size', '11px').attr('fill', '#9ca3af').text(label);
+                }
+            });
+        }
     }
 
-    function createOutcomeCategoryChart(processedData) {
-        const container = document.getElementById('outcomeCategoryChart');
-        if (!container) return;
-        d3.select('#outcomeCategoryChart').selectAll('*').remove();
+    function createOutcomeBarChart(deptStats, processedData, mode) {
+        if (mode === 'changetype') {
+            const deptChangeMap = {};
+            processedData.forEach(r => {
+                if (!deptChangeMap[r.department]) {
+                    deptChangeMap[r.department] = { department: r.department, total: 0, New: 0, More: 0, Different: 0, Less: 0, Cease: 0, None: 0 };
+                }
+                const d = deptChangeMap[r.department];
+                d.total++;
+                if (d[r.changeType] !== undefined) d[r.changeType]++;
+                else d.None++;
+            });
+            const changeStats = Object.values(deptChangeMap).sort((a, b) => b.total - a.total);
+            const ctKeys = ['New', 'More', 'Different', 'Less', 'Cease', 'None'];
+            buildHorizontalStackedBar('#outcomeBarChart', changeStats, 'department', ctKeys, changeTypeColors, changeTypeColors, null, null);
+        } else {
+            const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
+            const statusLabels = { actioned: 'Actioned', partial: 'Partial', no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending' };
+            buildHorizontalStackedBar('#outcomeBarChart', deptStats, 'department', statusKeys, outcomeStatusColor, statusLabels,
+                d => d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched',
+                'Grey = not yet researched (does not mean unactioned)');
+        }
+    }
 
-        // Aggregate by action category
+    function createOutcomeCategoryChart(processedData, mode) {
         const catMap = {};
         processedData.forEach(r => {
             const cat = r.actionCategory;
-            if (!catMap[cat]) {
-                catMap[cat] = {
-                    category: cat, total: 0,
-                    actioned: 0, partial: 0, no_evidence_found: 0, not_published: 0, pending: 0
-                };
-            }
+            if (!catMap[cat]) catMap[cat] = { category: cat, total: 0, actioned: 0, partial: 0, no_evidence_found: 0, not_published: 0, pending: 0, New: 0, More: 0, Different: 0, Less: 0, Cease: 0, None: 0 };
             const c = catMap[cat];
             c.total++;
             const s = r.enrichedOutcome && r.enrichedOutcome.evidence_status;
-            if (s && c[s] !== undefined) c[s]++;
-            else c.pending++;
+            if (s && c[s] !== undefined) c[s]++; else c.pending++;
+            if (c[r.changeType] !== undefined) c[r.changeType]++; else c.None++;
         });
 
-        const catStats = Object.values(catMap)
-            .map(c => ({ ...c, outstanding: c.partial + c.no_evidence_found + c.pending, coveragePct: Math.round((c.total - c.pending) / c.total * 100) }))
-            .sort((a, b) => b.outstanding - a.outstanding);
-
-        const isMobile = window.innerWidth < 768;
-        const margin = { top: 24, right: isMobile ? 90 : 150, bottom: 30, left: isMobile ? 150 : 210 };
-        const containerWidth = container.offsetWidth || 800;
-        const width = Math.max(containerWidth - margin.left - margin.right, 200);
-        const barHeight = 26;
-        const height = catStats.length * (barHeight + 10);
-
-        const svg = d3.select('#outcomeCategoryChart')
-            .append('svg')
-            .attr('viewBox', `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
-            .attr('width', '100%')
-            .attr('height', height + margin.top + margin.bottom)
-            .style('max-width', '1200px')
-            .append('g')
-            .attr('transform', `translate(${margin.left},${margin.top})`);
-
-        svg.append('text')
-            .attr('x', 0).attr('y', -8)
-            .attr('font-size', '11px').attr('fill', '#9ca3af')
-            .text('Grey = not yet researched (does not mean unactioned)');
-
-        const maxTotal = d3.max(catStats, d => d.total);
-        const x = d3.scaleLinear().domain([0, maxTotal]).range([0, width]);
-        const y = d3.scaleBand()
-            .domain(catStats.map(d => d.category))
-            .range([0, height])
-            .padding(0.2);
-
-        const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
-        const statusLabels = {
-            actioned: 'Actioned', partial: 'Partial',
-            no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending'
-        };
-
-        const stack = d3.stack().keys(statusKeys)(catStats);
-        stack.forEach(layer => {
-            svg.selectAll(`.cbar-${layer.key}`)
-                .data(layer)
-                .join('rect')
-                .attr('x', d => x(d[0]))
-                .attr('y', d => y(d.data.category))
-                .attr('width', d => Math.max(0, x(d[1]) - x(d[0])))
-                .attr('height', y.bandwidth())
-                .attr('fill', outcomeStatusColor[layer.key])
-                .append('title')
-                .text(d => `${d.data.category}\n${statusLabels[layer.key]}: ${d.data[layer.key]} (${Math.round(d.data[layer.key] / d.data.total * 100)}%)`);
-        });
-
-        svg.append('g')
-            .call(d3.axisLeft(y).tickSize(0))
-            .call(g => g.select('.domain').remove())
-            .selectAll('text')
-            .attr('font-size', isMobile ? '10px' : '12px')
-            .attr('fill', '#374151');
-
-        svg.append('g')
-            .attr('transform', `translate(0,${height})`)
-            .call(d3.axisBottom(x).ticks(5))
-            .call(g => g.select('.domain').remove());
-
-        catStats.forEach(d => {
-            svg.append('text')
-                .attr('x', x(d.total) + 6)
-                .attr('y', y(d.category) + y.bandwidth() / 2 + 4)
-                .attr('font-size', '11px')
-                .attr('fill', '#9ca3af')
-                .text(d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched');
-        });
+        if (mode === 'changetype') {
+            const catStats = Object.values(catMap).sort((a, b) => b.total - a.total);
+            const ctKeys = ['New', 'More', 'Different', 'Less', 'Cease', 'None'];
+            buildHorizontalStackedBar('#outcomeCategoryChart', catStats, 'category', ctKeys, changeTypeColors, changeTypeColors, null, null);
+        } else {
+            const catStats = Object.values(catMap)
+                .map(c => ({ ...c, outstanding: c.partial + c.no_evidence_found + c.pending, coveragePct: Math.round((c.total - c.pending) / c.total * 100) }))
+                .sort((a, b) => b.outstanding - a.outstanding);
+            const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
+            const statusLabels = { actioned: 'Actioned', partial: 'Partial', no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending' };
+            buildHorizontalStackedBar('#outcomeCategoryChart', catStats, 'category', statusKeys, outcomeStatusColor, statusLabels,
+                d => d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched',
+                'Grey = not yet researched (does not mean unactioned)');
+        }
     }
 
     // ── End outcome visualization helpers ───────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -93,6 +93,20 @@
             </p>
         </div>
 
+        <!-- Outcome Visualizations Section -->
+        <div id="outcomeSection" class="chart-container">
+            <h2>Recommendation Outcome Status</h2>
+            <div class="outcome-pending-note">
+                Only 4 of 20 inquiries (10.3% of recommendations) have been researched so far.
+                Grey = <strong>not yet researched</strong> — does not imply government inaction.
+            </div>
+            <div id="outcomeLegend" style="display:flex;flex-wrap:wrap;gap:12px;margin:12px 0 20px 0;font-size:13px;"></div>
+            <h3 style="color:#374151;margin-bottom:8px;">Outcomes by Department</h3>
+            <div id="outcomeBarChart" style="overflow-x:auto;margin-bottom:32px;"></div>
+            <h3 style="color:#374151;margin-bottom:8px;">Outcomes by Action Category</h3>
+            <div id="outcomeCategoryChart" style="overflow-x:auto;margin-bottom:16px;"></div>
+        </div>
+
         <h2>Inquiries Table</h2>
         <h3 style="text-align: center; color: #7c7b7b;"><i>Recommendations compiled from original inquiry PDFs with custom labels (defined above). Outcomes sourced from publicly available evidence.</i></h3>
         <div id="evidenceCountBadge"></div>
@@ -227,6 +241,14 @@
         "New": "#2ca02c",
         "Cease": "#d62728",
         "None": "#878c8f"
+    };
+
+    const outcomeStatusColor = {
+        actioned: "#10b981",
+        partial: "#f59e0b",
+        no_evidence_found: "#ef4444",
+        not_published: "#9ca3af",
+        pending: "#d1d5db"
     };
 
     // Fetch and process the data
@@ -649,14 +671,39 @@
             });
         });
 
-            // Transform data for sunburst chart
+            // Build status sub-nodes for an inquiry (used by dept sunburst)
+            function buildStatusChildren(inquiryName, totalRecs, enrichedMapRef) {
+                const counts = { actioned: 0, partial: 0, no_evidence_found: 0, not_published: 0, pending: 0 };
+                for (let i = 0; i < totalRecs; i++) {
+                    const entry = enrichedMapRef[`${inquiryName}__${i}`];
+                    const s = entry && entry.evidence_status;
+                    if (s && counts[s] !== undefined) counts[s]++;
+                    else counts.pending++;
+                }
+                const order = [
+                    { status: 'actioned',          label: 'Actioned' },
+                    { status: 'partial',            label: 'Partial' },
+                    { status: 'no_evidence_found',  label: 'No evidence found' },
+                    { status: 'not_published',      label: 'Not published' },
+                    { status: 'pending',            label: 'Research pending' },
+                ];
+                return order
+                    .filter(o => counts[o.status] > 0)
+                    .map(o => ({ name: o.label, value: counts[o.status], status: o.status }));
+            }
+
+            // Transform data for sunburst chart — inquiries split into status sub-nodes
             const hierarchicalData = {
                 name: "UK",
                 children: data.map(dept => ({
                     name: dept['Administration-or-Department'],
                     children: dept.Inquiries.map(inquiry => ({
                         name: inquiry.InquiryName,
-                        value: inquiry.Recommendations ? inquiry.Recommendations.length : 0
+                        children: buildStatusChildren(
+                            inquiry.InquiryName,
+                            inquiry.Recommendations ? inquiry.Recommendations.length : 0,
+                            enrichedMap
+                        )
                     }))
                 }))
             };
@@ -700,12 +747,232 @@
             // Create D3 visualizations
             createZoomableSunburst(hierarchicalData, "#sunburstChart");
             createZoomableSunburst(actionsData, "#actionsSunburstChart");
+            // Create outcome visualizations
+            const deptStats = computeOutcomeStats(processedData);
+            createOutcomeLegend();
+            createOutcomeBarChart(deptStats);
+            createOutcomeCategoryChart(processedData);
             console.log("All charts created successfully");
         })
         .catch(error => {
             console.error("Error loading or processing data:", error);
             document.querySelector('.container').innerHTML += '<div style="background: #ffdddd; padding: 20px; margin: 20px; border-radius: 5px; border: 2px solid #ff0000;"><h2>Error Loading Data</h2><p>Could not load data files. Error: ' + error.message + '</p><p><strong>Possible solutions:</strong></p><ul><li>Make sure you are running this page through a web server (not file://)</li><li>Check that data.json and enriched_data.json exist in the same folder as index.html</li><li>Open browser console (F12) for more details</li></ul></div>';
         });
+
+    // ── Outcome visualization helpers ───────────────────────────────────────
+
+    function computeOutcomeStats(processedData) {
+        const deptMap = {};
+        processedData.forEach(r => {
+            if (!deptMap[r.department]) {
+                deptMap[r.department] = {
+                    department: r.department, total: 0,
+                    actioned: 0, partial: 0, no_evidence_found: 0, not_published: 0, pending: 0
+                };
+            }
+            const d = deptMap[r.department];
+            d.total++;
+            const s = r.enrichedOutcome && r.enrichedOutcome.evidence_status;
+            if (s && d[s] !== undefined) d[s]++;
+            else d.pending++;
+        });
+        return Object.values(deptMap).map(d => ({
+            ...d,
+            outstanding: d.partial + d.no_evidence_found + d.pending,
+            coveragePct: Math.round((d.total - d.pending) / d.total * 100)
+        })).sort((a, b) => b.outstanding - a.outstanding);
+    }
+
+    function createOutcomeLegend() {
+        const container = document.getElementById('outcomeLegend');
+        if (!container) return;
+        const items = [
+            { label: 'Actioned',               color: '#10b981' },
+            { label: 'Partial evidence',        color: '#f59e0b' },
+            { label: 'No evidence found',       color: '#ef4444' },
+            { label: 'Not published',           color: '#9ca3af' },
+            { label: 'Research pending',        color: '#d1d5db', border: '#9ca3af' },
+        ];
+        items.forEach(item => {
+            const span = document.createElement('span');
+            span.style.cssText = 'display:inline-flex;align-items:center;gap:6px;';
+            span.innerHTML = `<span style="width:14px;height:14px;border-radius:3px;background:${item.color};border:1px solid ${item.border || item.color};display:inline-block;flex-shrink:0;"></span><span>${item.label}</span>`;
+            container.appendChild(span);
+        });
+    }
+
+    function createOutcomeBarChart(deptStats) {
+        const container = document.getElementById('outcomeBarChart');
+        if (!container) return;
+        d3.select('#outcomeBarChart').selectAll('*').remove();
+
+        const isMobile = window.innerWidth < 768;
+        const margin = { top: 24, right: isMobile ? 90 : 150, bottom: 30, left: isMobile ? 150 : 210 };
+        const containerWidth = container.offsetWidth || 800;
+        const width = Math.max(containerWidth - margin.left - margin.right, 200);
+        const barHeight = 26;
+        const height = deptStats.length * (barHeight + 10);
+
+        const svg = d3.select('#outcomeBarChart')
+            .append('svg')
+            .attr('viewBox', `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
+            .attr('width', '100%')
+            .attr('height', height + margin.top + margin.bottom)
+            .style('max-width', '1200px')
+            .append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`);
+
+        svg.append('text')
+            .attr('x', 0).attr('y', -8)
+            .attr('font-size', '11px').attr('fill', '#9ca3af')
+            .text('Grey = not yet researched (does not mean unactioned)');
+
+        const maxTotal = d3.max(deptStats, d => d.total);
+        const x = d3.scaleLinear().domain([0, maxTotal]).range([0, width]);
+        const y = d3.scaleBand()
+            .domain(deptStats.map(d => d.department))
+            .range([0, height])
+            .padding(0.2);
+
+        const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
+        const statusLabels = {
+            actioned: 'Actioned', partial: 'Partial',
+            no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending'
+        };
+
+        const stack = d3.stack().keys(statusKeys)(deptStats);
+        stack.forEach(layer => {
+            svg.selectAll(`.bar-seg-${layer.key}`)
+                .data(layer)
+                .join('rect')
+                .attr('x', d => x(d[0]))
+                .attr('y', d => y(d.data.department))
+                .attr('width', d => Math.max(0, x(d[1]) - x(d[0])))
+                .attr('height', y.bandwidth())
+                .attr('fill', outcomeStatusColor[layer.key])
+                .append('title')
+                .text(d => `${d.data.department}\n${statusLabels[layer.key]}: ${d.data[layer.key]} (${Math.round(d.data[layer.key] / d.data.total * 100)}%)`);
+        });
+
+        svg.append('g')
+            .call(d3.axisLeft(y).tickSize(0))
+            .call(g => g.select('.domain').remove())
+            .selectAll('text')
+            .attr('font-size', isMobile ? '10px' : '12px')
+            .attr('fill', '#374151');
+
+        svg.append('g')
+            .attr('transform', `translate(0,${height})`)
+            .call(d3.axisBottom(x).ticks(5))
+            .call(g => g.select('.domain').remove());
+
+        deptStats.forEach(d => {
+            svg.append('text')
+                .attr('x', x(d.total) + 6)
+                .attr('y', y(d.department) + y.bandwidth() / 2 + 4)
+                .attr('font-size', '11px')
+                .attr('fill', '#9ca3af')
+                .text(d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched');
+        });
+    }
+
+    function createOutcomeCategoryChart(processedData) {
+        const container = document.getElementById('outcomeCategoryChart');
+        if (!container) return;
+        d3.select('#outcomeCategoryChart').selectAll('*').remove();
+
+        // Aggregate by action category
+        const catMap = {};
+        processedData.forEach(r => {
+            const cat = r.actionCategory;
+            if (!catMap[cat]) {
+                catMap[cat] = {
+                    category: cat, total: 0,
+                    actioned: 0, partial: 0, no_evidence_found: 0, not_published: 0, pending: 0
+                };
+            }
+            const c = catMap[cat];
+            c.total++;
+            const s = r.enrichedOutcome && r.enrichedOutcome.evidence_status;
+            if (s && c[s] !== undefined) c[s]++;
+            else c.pending++;
+        });
+
+        const catStats = Object.values(catMap)
+            .map(c => ({ ...c, outstanding: c.partial + c.no_evidence_found + c.pending, coveragePct: Math.round((c.total - c.pending) / c.total * 100) }))
+            .sort((a, b) => b.outstanding - a.outstanding);
+
+        const isMobile = window.innerWidth < 768;
+        const margin = { top: 24, right: isMobile ? 90 : 150, bottom: 30, left: isMobile ? 150 : 210 };
+        const containerWidth = container.offsetWidth || 800;
+        const width = Math.max(containerWidth - margin.left - margin.right, 200);
+        const barHeight = 26;
+        const height = catStats.length * (barHeight + 10);
+
+        const svg = d3.select('#outcomeCategoryChart')
+            .append('svg')
+            .attr('viewBox', `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
+            .attr('width', '100%')
+            .attr('height', height + margin.top + margin.bottom)
+            .style('max-width', '1200px')
+            .append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`);
+
+        svg.append('text')
+            .attr('x', 0).attr('y', -8)
+            .attr('font-size', '11px').attr('fill', '#9ca3af')
+            .text('Grey = not yet researched (does not mean unactioned)');
+
+        const maxTotal = d3.max(catStats, d => d.total);
+        const x = d3.scaleLinear().domain([0, maxTotal]).range([0, width]);
+        const y = d3.scaleBand()
+            .domain(catStats.map(d => d.category))
+            .range([0, height])
+            .padding(0.2);
+
+        const statusKeys = ['actioned', 'partial', 'no_evidence_found', 'not_published', 'pending'];
+        const statusLabels = {
+            actioned: 'Actioned', partial: 'Partial',
+            no_evidence_found: 'No evidence found', not_published: 'Not published', pending: 'Research pending'
+        };
+
+        const stack = d3.stack().keys(statusKeys)(catStats);
+        stack.forEach(layer => {
+            svg.selectAll(`.cbar-${layer.key}`)
+                .data(layer)
+                .join('rect')
+                .attr('x', d => x(d[0]))
+                .attr('y', d => y(d.data.category))
+                .attr('width', d => Math.max(0, x(d[1]) - x(d[0])))
+                .attr('height', y.bandwidth())
+                .attr('fill', outcomeStatusColor[layer.key])
+                .append('title')
+                .text(d => `${d.data.category}\n${statusLabels[layer.key]}: ${d.data[layer.key]} (${Math.round(d.data[layer.key] / d.data.total * 100)}%)`);
+        });
+
+        svg.append('g')
+            .call(d3.axisLeft(y).tickSize(0))
+            .call(g => g.select('.domain').remove())
+            .selectAll('text')
+            .attr('font-size', isMobile ? '10px' : '12px')
+            .attr('fill', '#374151');
+
+        svg.append('g')
+            .attr('transform', `translate(0,${height})`)
+            .call(d3.axisBottom(x).ticks(5))
+            .call(g => g.select('.domain').remove());
+
+        catStats.forEach(d => {
+            svg.append('text')
+                .attr('x', x(d.total) + 6)
+                .attr('y', y(d.category) + y.bandwidth() / 2 + 4)
+                .attr('font-size', '11px')
+                .attr('fill', '#9ca3af')
+                .text(d.coveragePct > 0 ? `${d.coveragePct}% researched` : 'not yet researched');
+        });
+    }
+
+    // ── End outcome visualization helpers ───────────────────────────────────
 
     // Function to create stacked bar chart
     function createStackedBarChart(data) {
@@ -1143,16 +1410,21 @@
             .data(root.descendants().slice(1))
             .join("path")
             .attr("fill", d => {
-                if (d.depth === 3) {
+                if (d.data.status) {
+                    return outcomeStatusColor[d.data.status] || "#d1d5db";
+                } else if (d.depth === 3) {
                     return actionCategoryColors[d.data.name] || color(d.data.name);
                 } else if (d.depth === 4) {
                     return changeTypeColors[d.data.name] || color(d.data.name);
                 } else {
-                    while (d.depth > 1) d = d.parent;
-                    return color(d.data.name);
+                    let node = d;
+                    while (node.depth > 1) node = node.parent;
+                    return color(node.data.name);
                 }
             })
             .attr("fill-opacity", d => arcVisible(d.current) ? (d.children ? 0.6 : 0.4) : 0)
+            .attr("stroke", d => d.data.status ? "white" : "none")
+            .attr("stroke-width", d => d.data.status ? 0.5 : 0)
             .attr("pointer-events", d => arcVisible(d.current) ? "auto" : "none")
             .attr("d", d => arc(d.current));
 

--- a/styles.css
+++ b/styles.css
@@ -343,3 +343,27 @@ tr:hover {
 }
 .ev-badge-partial  { background: #fef3c7; color: #92400e; }
 .ev-badge-complete { background: #d1fae5; color: #065f46; }
+
+/* ── Outcome visualizations section ──────────────────────── */
+.outcome-pending-note {
+    background: #f9fafb;
+    border-left: 4px solid #9ca3af;
+    padding: 10px 16px;
+    font-size: 13px;
+    color: #555;
+    border-radius: 0 6px 6px 0;
+    margin-bottom: 16px;
+}
+
+#outcomeSection h3 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-top: 24px;
+}
+
+@media screen and (max-width: 768px) {
+    #outcomeBarChart,
+    #outcomeHeatmap {
+        min-width: 0;
+    }
+}


### PR DESCRIPTION
## Summary

- New **"Recommendation Outcome Status"** section between the contribution banner and the table, containing:
  - **Outcomes by Department** — stacked horizontal bar chart showing actioned / partial / no evidence found / not published / research pending per department, with coverage % labels
  - **Outcomes by Action Category** — same chart format, by action category
  - Shared legend strip (actioned = green, partial = amber, no evidence = red, not published = grey, pending = light grey)
- **Dept sunburst** (`#sunburstChart`) updated: each inquiry arc is now split into outcome-status sub-nodes ordered actioned → partial → pending, making the outer ring a natural progress indicator. `#actionsSunburstChart` is unchanged.
- Clear caveat note: grey = not yet researched, not evidence of inaction (only 4 of 20 inquiries are enriched so far)

## Test plan

- [x] Open dashboard — "Recommendation Outcome Status" section appears between contribution banner and table
- [x] Dept and category bar charts render; hovering a segment shows tooltip with counts
- [x] Sunburst outer arcs show green/amber/grey breakdown per inquiry; click zoom still works
- [x] `#actionsSunburstChart` looks unchanged
- [x] Mobile: bar charts scroll horizontally; layout intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)