### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,9 @@ name: Validate data files
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Daphnis605/uk_inquiry_dashboard/security/code-scanning/1](https://github.com/Daphnis605/uk_inquiry_dashboard/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/validate.yml` at the workflow root (top-level), just below the trigger section (`on:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe permission is:

- `contents: read`

This preserves current behavior (checkout + validation) while preventing unintended write-capable token scopes if defaults are permissive.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
