### PR TITLE
Research tooling: web search, reject workflow, BMC widget, CI fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -131,38 +131,46 @@ jobs:
           with open('enriched_data.json') as f:
               data = json.load(f)
 
-          failed = []
-          checked = 0
+          # Collect unique URLs — many recommendations share the same source
+          seen = set()
+          urls_to_check = []
           for key, outcome in data.items():
               if key.startswith('_'):
                   continue
               for ev in outcome.get('evidence', []):
                   if ev.get('rejected', False):
-                      continue  # rejected URL markers are not live evidence
-                  url = ev.get('url', '')
-                  if not url:
                       continue
-                  try:
-                      req = urllib.request.Request(url, method='HEAD', headers={
-                          'User-Agent': 'Mozilla/5.0 (uk-inquiry-dashboard CI url-check)'
-                      })
-                      with urllib.request.urlopen(req, timeout=10) as resp:
-                          status = resp.status
-                          if status >= 400:
-                              failed.append((key, url, status))
-                          else:
-                              checked += 1
-                              print(f"  OK {status}: {url}")
-                  except urllib.error.HTTPError as e:
-                      if e.code in (403, 405, 406):
-                          # Some servers reject HEAD or block CI user-agents — not a broken URL
-                          checked += 1
-                          print(f"  OK (HEAD blocked, {e.code}): {url}")
+                  url = ev.get('url', '')
+                  if url and url not in seen:
+                      seen.add(url)
+                      urls_to_check.append((key, url))
+
+          print(f"Checking {len(urls_to_check)} unique URL(s)")
+
+          failed = []
+          checked = 0
+          for key, url in urls_to_check:
+              try:
+                  req = urllib.request.Request(url, method='HEAD', headers={
+                      'User-Agent': 'Mozilla/5.0 (uk-inquiry-dashboard CI url-check)'
+                  })
+                  with urllib.request.urlopen(req, timeout=10) as resp:
+                      status = resp.status
+                      if status >= 400:
+                          failed.append((key, url, status))
                       else:
-                          failed.append((key, url, e.code))
-                  except Exception as e:
-                      failed.append((key, url, str(e)))
-                  time.sleep(0.5)  # be polite to servers
+                          checked += 1
+                          print(f"  OK {status}: {url}")
+              except urllib.error.HTTPError as e:
+                  if e.code in (403, 405, 406):
+                      # Some servers reject HEAD or block CI user-agents — not a broken URL
+                      checked += 1
+                      print(f"  OK (HEAD blocked, {e.code}): {url}")
+                  else:
+                      failed.append((key, url, e.code))
+              except Exception as e:
+                  failed.append((key, url, str(e)))
+              time.sleep(0.5)  # be polite to servers
 
           if failed:
               print("\nFAILED URL checks:", file=sys.stderr)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -96,6 +96,8 @@ jobs:
               if key.startswith('_') or not isinstance(entry, dict):
                   continue
               for i, ev in enumerate(entry.get('evidence', [])):
+                  if ev.get('rejected', False):
+                      continue  # rejected items are kept as URL markers, not evidence
                   if not ev.get('approved', False):
                       title = ev.get('title', '(no title)')[:60]
                       unapproved.append(f"  {key}  item {i}: {title}")
@@ -135,6 +137,8 @@ jobs:
               if key.startswith('_'):
                   continue
               for ev in outcome.get('evidence', []):
+                  if ev.get('rejected', False):
+                      continue  # rejected URL markers are not live evidence
                   url = ev.get('url', '')
                   if not url:
                       continue

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ coverage/
 *.old
 *.orig
 *.rej
+# Research audit logs
+*.jsonl
+
+# PDF source documents
+data/

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                     </a>
                 </div>
                 <a href="https://buymeacoffee.com/daphnis605" target="_blank" style="background: #FFDD00; color: #000; padding: 15px 30px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 16px; box-shadow: 0 4px 10px rgba(0,0,0,0.2); transition: transform 0.2s, box-shadow 0.2s; display: inline-block;">
-                    <span aria-hidden="true">☕</span> Buy Me a Hot Chocolate
+                    <span aria-hidden="true">🪙</span> Buy Me a Token
                 </a>
             </div>
 
@@ -1744,6 +1744,6 @@
     </script>
 
     <!-- Buy Me a Coffee Widget -->
-    <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="daphnis605" data-description="Support me on Buy me a coffee!" data-message="Free way to support: Submit outcome links (Google Form)" data-color="#BD5FFF" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
+    <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="daphnis605" data-description="Support me on Buy me a coffee!" data-message="Each recommendation costs ~£0.02 in AI tokens to research. Buy me a token to help cover it!" data-color="#BD5FFF" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
 </body>
 </html>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,9 +77,20 @@ See [tools/review_app/README.md](../tools/review_app/README.md) for full review 
 - Official government report confirming implementation (`gov.uk`, `nao.org.uk`, etc.)
 - Ministerial statement or press release announcing the action
 - Parliamentary record confirming the change was made
+- A credible news article or public body page confirming the thing is in place (where no primary source is available)
 
 **Not sufficient:** acceptance letters, welcome statements, progress reviews without
-confirmation of implementation, or news articles without primary source.
+confirmation of implementation.
+
+### What gets rejected
+
+AI proposals are rejected in the review app when:
+- The URL no longer exists or doesn't contain the claimed content
+- The source mentions the inquiry but doesn't confirm the recommendation was actually implemented
+- The source is an acceptance or welcome of a recommendation, not evidence of action taken
+- The URL is for a different recommendation or a different inquiry
+
+Rejected URLs are kept as markers so the research script doesn't re-propose the same URL on future runs.
 
 ### Cost
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,8 +36,8 @@ python scripts/research.py --audit-log audit.jsonl
 # Disable web search (training knowledge only — faster, cheaper, less accurate)
 python scripts/research.py --no-web-search
 
-# Cheaper/faster model for a first-pass sweep
-python scripts/research.py --model claude-haiku-4-5-20251001 --limit 100
+# Use Sonnet for a higher-quality second pass on items Haiku couldn't find
+python scripts/research.py --model claude-sonnet-4-6 --limit 50
 ```
 
 ### Training knowledge vs. web search
@@ -86,5 +86,5 @@ confirmation of implementation, or news articles without primary source.
 Check current pricing at [anthropic.com/pricing](https://www.anthropic.com/pricing).
 Each recommendation uses roughly 400 input tokens and 300 output tokens (more with web search).
 
-A practical approach: run Haiku first for broad coverage, then Sonnet on
-the recommendations Haiku couldn't find evidence for.
+Haiku is the default — good for broad coverage at low cost. Switch to Sonnet
+(`--model claude-sonnet-4-6`) for a higher-quality pass on items Haiku couldn't find.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,3 +88,46 @@ Each recommendation uses roughly 400 input tokens and 300 output tokens (more wi
 
 Haiku is the default — good for broad coverage at low cost. Switch to Sonnet
 (`--model claude-sonnet-4-6`) for a higher-quality pass on items Haiku couldn't find.
+
+---
+
+## batch_research.py — full sweep across all inquiries
+
+Runs `research.py` across all 21 target inquiries in priority order, with
+automatic pacing and gates to stop if the API is misbehaving.
+
+Excluded from the batch (covered by official UK inquiry dashboards):
+Manchester Arena, Grenfell Tower, Infected Blood.
+
+### Usage
+
+```bash
+# Preview the plan (no API calls)
+python scripts/batch_research.py --list
+
+# Full sweep (Haiku, web search on)
+python scripts/batch_research.py
+
+# Resume after a break
+python scripts/batch_research.py --from "Leveson"
+
+# Higher quality second pass
+python scripts/batch_research.py --model claude-sonnet-4-6
+
+# Save a full audit log
+python scripts/batch_research.py --audit-log batch_audit.jsonl
+```
+
+### Pacing
+
+Web search is capped at 1 search per call (`max_uses: 1`), keeping each call to
+~15–40k input tokens against the Haiku 50k ITPM limit. Sleep between requests is
+computed dynamically: `max(60s, tokens/50k × 60s + 15s)` — typically 60s per rec.
+Full sweep of ~463 non-Mid Staffs recs takes ~8 hours; use `--from` to split across
+multiple sessions.
+
+### Gates
+
+If more than 60% of recs in an inquiry return `no_response` (exhausted retries),
+the script pauses and asks whether to continue. Non-zero exit from `research.py`
+stops the batch immediately.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,8 +36,8 @@ python scripts/research.py --audit-log audit.jsonl
 # Disable web search (training knowledge only — faster, cheaper, less accurate)
 python scripts/research.py --no-web-search
 
-# Use Sonnet for a higher-quality second pass on items Haiku couldn't find
-python scripts/research.py --model claude-sonnet-4-6 --limit 50
+# Cheaper/faster model for a first-pass sweep
+python scripts/research.py --model claude-haiku-4-5-20251001 --limit 100
 ```
 
 ### Training knowledge vs. web search
@@ -86,5 +86,5 @@ confirmation of implementation, or news articles without primary source.
 Check current pricing at [anthropic.com/pricing](https://www.anthropic.com/pricing).
 Each recommendation uses roughly 400 input tokens and 300 output tokens (more with web search).
 
-Haiku is the default — good for broad coverage at low cost. Switch to Sonnet
-(`--model claude-sonnet-4-6`) for a higher-quality pass on items Haiku couldn't find.
+A practical approach: run Haiku first for broad coverage, then Sonnet on
+the recommendations Haiku couldn't find evidence for.

--- a/scripts/batch_research.py
+++ b/scripts/batch_research.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+Batch runner for research.py — works through all inquiries that have
+unevidenced recommendations, in descending order of unevidenced count.
+
+Usage:
+    # Preview the plan without running anything
+    python scripts/batch_research.py --list
+
+    # Full run (Haiku, web search on)
+    python scripts/batch_research.py
+
+    # Skip specific inquiries (substrings, comma-separated)
+    python scripts/batch_research.py --skip "Manchester Arena,Grenfell,Infected Blood"
+
+    # Resume after a break (substring match)
+    python scripts/batch_research.py --from "Leveson"
+
+    # Dry run — API calls happen but nothing is written to disk
+    python scripts/batch_research.py --dry-run
+
+    # Higher quality second pass
+    python scripts/batch_research.py --model claude-sonnet-4-6
+
+    # Full audit log
+    python scripts/batch_research.py --audit-log batch_audit.jsonl
+"""
+
+import json
+import subprocess
+import sys
+import time
+import argparse
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+RESEARCH_SCRIPT = ROOT / "scripts" / "research.py"
+DATA_JSON = ROOT / "data.json"
+ENRICHED_JSON = ROOT / "enriched_data.json"
+
+# ---------------------------------------------------------------------------
+# Gate thresholds
+# ---------------------------------------------------------------------------
+
+# Stop and prompt if this fraction of recs come back as no_response
+NO_RESPONSE_GATE = 0.6
+
+# Default pause between inquiries (seconds) — lets the TPM window fully reset
+DEFAULT_INTER_INQUIRY_PAUSE = 120
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_unevidenced_counts(skip_names: list[str]) -> list[tuple[str, int]]:
+    """
+    Return list of (inquiry_name, unevidenced_count) sorted descending,
+    excluding inquiries whose names contain any of the skip substrings.
+    """
+    data = json.loads(DATA_JSON.read_text(encoding="utf-8"))
+    enriched = json.loads(ENRICHED_JSON.read_text(encoding="utf-8"))
+
+    counts: dict[str, int] = {}
+    for dept in data:
+        for inquiry in dept.get("Inquiries", []):
+            name = inquiry["InquiryName"]
+            for idx, _ in enumerate(inquiry.get("Recommendations", [])):
+                key = f"{name}__{idx}"
+                existing = enriched.get(key)
+                has_approved = (
+                    existing
+                    and existing.get("evidence")
+                    and any(ev.get("approved") for ev in existing["evidence"])
+                )
+                if not has_approved:
+                    counts[name] = counts.get(name, 0) + 1
+
+    results = [
+        (name, count)
+        for name, count in counts.items()
+        if not any(s.lower() in name.lower() for s in skip_names if s)
+    ]
+    results.sort(key=lambda x: -x[1])
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_inquiry(
+    name: str,
+    limit: int,
+    *,
+    dry_run: bool,
+    model: str,
+    audit_log: str | None,
+    no_web_search: bool,
+    start_from: int = 1,
+) -> dict:
+    """
+    Run research.py for one inquiry, streaming stderr to the terminal.
+    Returns {name, returncode, attempted, no_response}.
+    """
+    cmd = [
+        sys.executable, str(RESEARCH_SCRIPT),
+        "--inquiry", name,
+        "--limit", str(limit),
+        "--model", model,
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+    if audit_log:
+        cmd += ["--audit-log", audit_log]
+    if no_web_search:
+        cmd.append("--no-web-search")
+    if start_from > 1:
+        cmd += ["--start-from", str(start_from)]
+
+    attempted = 0
+    no_response = 0
+
+    try:
+        proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
+        for line in proc.stderr:
+            sys.stderr.write(line)
+            sys.stderr.flush()
+            stripped = line.strip()
+            if stripped.startswith("[") and "/" in stripped:
+                attempted += 1
+            if "→ no_response" in stripped:
+                no_response += 1
+        proc.wait()
+        return {"name": name, "returncode": proc.returncode, "attempted": attempted, "no_response": no_response}
+    except KeyboardInterrupt:
+        proc.terminate()
+        raise
+
+
+def check_gate(stats: dict) -> bool:
+    """Return True if safe to continue; prompts user if gate fires."""
+    attempted, no_response = stats["attempted"], stats["no_response"]
+    if attempted == 0 or no_response / attempted < NO_RESPONSE_GATE:
+        return True
+    rate = no_response / attempted
+    print(
+        f"\n⚠  Gate: {no_response}/{attempted} recs returned no_response ({rate:.0%}). "
+        f"This usually means persistent rate limit failures.",
+        file=sys.stderr,
+    )
+    return input("   Continue to next inquiry? [y/N] ").strip().lower() == "y"
+
+
+def commit_inquiry(name: str) -> bool:
+    """
+    Stage enriched_data.json and commit if there are changes.
+    Returns True if a commit was made, False if nothing changed.
+    """
+    # Check whether enriched_data.json actually changed
+    diff = subprocess.run(
+        ["git", "diff", "--quiet", "enriched_data.json"],
+        cwd=ROOT,
+    )
+    if diff.returncode == 0:
+        print("  (no changes to enriched_data.json — nothing to commit)", file=sys.stderr)
+        return False
+
+    subprocess.run(["git", "add", "enriched_data.json"], cwd=ROOT, check=True)
+    msg = f"Research: {name} — AI-assisted evidence proposals (approved:false)"
+    result = subprocess.run(["git", "commit", "-m", msg], cwd=ROOT)
+    if result.returncode == 0:
+        print(f"  ✓ Committed enriched_data.json for: {name}", file=sys.stderr)
+        return True
+    else:
+        print("  ⚠ git commit failed — continuing without commit", file=sys.stderr)
+        return False
+
+
+def pause_between(seconds: int) -> None:
+    print(f"\nPausing {seconds}s before next inquiry…", file=sys.stderr, flush=True)
+    for remaining in range(seconds, 0, -15):
+        print(f"  {remaining}s remaining…", end="\r", file=sys.stderr, flush=True)
+        time.sleep(min(15, remaining))
+    print(file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Batch-run research.py across all inquiries with unevidenced recommendations."
+    )
+    parser.add_argument("--list", action="store_true", help="Print plan and exit")
+    parser.add_argument("--skip", metavar="NAMES",
+                        help="Comma-separated substrings of inquiry names to skip")
+    parser.add_argument("--from", dest="from_inquiry", metavar="NAME",
+                        help="Skip ahead to the first inquiry matching this substring")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Pass --dry-run to research.py (nothing written to disk)")
+    parser.add_argument("--no-web-search", action="store_true")
+    parser.add_argument("--model", default="claude-haiku-4-5-20251001")
+    parser.add_argument("--audit-log", metavar="FILE")
+    parser.add_argument("--pause", type=int, default=DEFAULT_INTER_INQUIRY_PAUSE, metavar="SECS",
+                        help=f"Seconds between inquiries (default: {DEFAULT_INTER_INQUIRY_PAUSE})")
+    parser.add_argument("--commit-each", action="store_true",
+                        help="git commit enriched_data.json after each inquiry (useful for long runs)")
+    parser.add_argument("--start-from", type=int, default=1, metavar="N",
+                        help="For the first inquiry in the queue, skip recommendations numbered below N (resume mid-inquiry)")
+    args = parser.parse_args()
+
+    skip_names = [s.strip() for s in (args.skip or "").split(",")]
+    queue = load_unevidenced_counts(skip_names)
+
+    if not queue:
+        print("No unevidenced recommendations found.", file=sys.stderr)
+        return
+
+    if args.list:
+        total_recs = sum(c for _, c in queue)
+        mode = "training knowledge" if args.no_web_search else "web search"
+        print(f"Batch plan — {len(queue)} inquiries, {total_recs} unevidenced recs")
+        commit_note = "  |  --commit-each" if args.commit_each else ""
+        print(f"Model: {args.model}  |  mode: {mode}  |  pause: {args.pause}s{commit_note}\n")
+        for i, (name, count) in enumerate(queue, 1):
+            print(f"  {i:2d}. [{count:3d} recs]  {name}")
+        secs_per_rec = 65 if not args.no_web_search else 1
+        print(f"\nEstimated time: ~{total_recs * secs_per_rec / 3600:.1f} hours continuous")
+        print("Tip: use --from NAME to resume after a break.")
+        return
+
+    if args.from_inquiry:
+        start = next(
+            (i for i, (name, _) in enumerate(queue)
+             if args.from_inquiry.lower() in name.lower()),
+            None,
+        )
+        if start is None:
+            print(f"ERROR: --from '{args.from_inquiry}' matched no inquiry.", file=sys.stderr)
+            sys.exit(1)
+        queue = queue[start:]
+        print(f"Resuming from: {queue[0][0]}\n", file=sys.stderr)
+
+    total = len(queue)
+    mode = "web search" if not args.no_web_search else "training knowledge only"
+    print(
+        f"Batch starting: {total} inquiries  |  model={args.model}  |  "
+        f"pause={args.pause}s  |  {mode}",
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        print("DRY RUN — nothing will be written to enriched_data.json", file=sys.stderr)
+    if args.commit_each and not args.dry_run:
+        print("--commit-each: will git commit enriched_data.json after each inquiry", file=sys.stderr)
+    print(file=sys.stderr)
+
+    completed = 0
+    try:
+        for i, (name, limit) in enumerate(queue):
+            print(f"\n{'=' * 60}", file=sys.stderr)
+            print(f"[{i + 1}/{total}] {name}  ({limit} unevidenced)", file=sys.stderr)
+            print(f"{'=' * 60}", file=sys.stderr)
+
+            stats = run_inquiry(
+                name, limit,
+                dry_run=args.dry_run,
+                model=args.model,
+                audit_log=args.audit_log,
+                no_web_search=args.no_web_search,
+                start_from=args.start_from if i == 0 else 1,
+            )
+            completed += 1
+
+            if stats["returncode"] not in (0, None):
+                print(f"\n✗  research.py exited {stats['returncode']} — stopping.", file=sys.stderr)
+                sys.exit(1)
+
+            if not check_gate(stats):
+                print("\nStopped by user after gate check.", file=sys.stderr)
+                sys.exit(0)
+
+            if args.commit_each and not args.dry_run:
+                commit_inquiry(name)
+
+            if i < total - 1:
+                pause_between(args.pause)
+
+    except KeyboardInterrupt:
+        remaining_name = queue[completed][0] if completed < total else ""
+        resume = f'--from "{remaining_name}"' if remaining_name else ""
+        print(
+            f"\n\nInterrupted after {completed}/{total} inquiries."
+            + (f"\nResume with: python scripts/batch_research.py {resume}" if resume else ""),
+            file=sys.stderr,
+        )
+        sys.exit(130)
+
+    print(f"\n✓  All {completed} inquiries processed.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/batch_research.py
+++ b/scripts/batch_research.py
@@ -120,6 +120,7 @@ def run_inquiry(
 
     attempted = 0
     no_response = 0
+    last_rec = 0
 
     try:
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
@@ -129,10 +130,14 @@ def run_inquiry(
             stripped = line.strip()
             if stripped.startswith("[") and "/" in stripped:
                 attempted += 1
+                # Parse rec number from lines like "[3/288] Inquiry rec 42"
+                rec_match = __import__("re").search(r"\brec (\d+)$", stripped)
+                if rec_match:
+                    last_rec = int(rec_match.group(1))
             if "→ no_response" in stripped:
                 no_response += 1
         proc.wait()
-        return {"name": name, "returncode": proc.returncode, "attempted": attempted, "no_response": no_response}
+        return {"name": name, "returncode": proc.returncode, "attempted": attempted, "no_response": no_response, "last_rec": last_rec}
     except KeyboardInterrupt:
         proc.terminate()
         raise
@@ -273,6 +278,11 @@ def main() -> None:
             )
             completed += 1
 
+            if stats["returncode"] == 2:
+                print(f"\n💳  Billing limit reached after {completed}/{total} inquiries — stopping.", file=sys.stderr)
+                resume = f'--from "{name}" --start-from {stats["last_rec"] + 1}' if stats.get("last_rec") else f'--from "{name}"'
+                print(f"Resume next month with: python scripts/batch_research.py {resume}", file=sys.stderr)
+                sys.exit(2)
             if stats["returncode"] not in (0, None):
                 print(f"\n✗  research.py exited {stats['returncode']} — stopping.", file=sys.stderr)
                 sys.exit(1)

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -426,7 +426,7 @@ def main() -> None:
             new_keys += 1
             new_items += len(proposal.get("evidence", []))
         else:
-            existing_urls = {ev.get("url") for ev in enriched[key].get("evidence", [])}
+            existing_urls = {ev.get("url") for ev in enriched[key].get("evidence", []) if ev.get("url")}
             for ev in proposal.get("evidence", []):
                 if ev.get("url") not in existing_urls:
                     enriched[key].setdefault("evidence", []).append(ev)

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -211,13 +211,21 @@ def research_recommendation(
     if web_search:
         kwargs["tools"] = [{"type": "web_search_20250305", "name": "web_search"}]
 
-    try:
-        message = client.messages.create(**kwargs)
-        raw = extract_final_text(message)
-        return parse_response(raw), raw
-    except Exception as e:
-        print(f"  API error: {e}", file=sys.stderr)
-        return None, ""
+    for attempt in range(3):
+        try:
+            message = client.messages.create(**kwargs)
+            raw = extract_final_text(message)
+            return parse_response(raw), raw
+        except Exception as e:
+            err = str(e)
+            if "rate_limit_error" in err and attempt < 2:
+                wait = 30 * (attempt + 1)
+                print(f"  Rate limit hit — waiting {wait}s before retry {attempt + 2}/3…", file=sys.stderr)
+                time.sleep(wait)
+            else:
+                print(f"  API error: {e}", file=sys.stderr)
+                return None, ""
+    return None, ""
 
 
 def write_audit_entry(audit_file: IO, rec: dict, result: dict | None, raw: str) -> None:
@@ -335,7 +343,7 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(0.3)  # stay within rate limits
+                time.sleep(5 if use_web_search else 0.3)  # web search responses are larger
     finally:
         if audit_file:
             audit_file.close()

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -282,8 +282,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="claude-sonnet-4-6",
-        help="Claude model ID (default: claude-sonnet-4-6)",
+        default="claude-haiku-4-5-20251001",
+        help="Claude model ID (default: claude-haiku-4-5-20251001)",
     )
     args = parser.parse_args()
 

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -217,7 +217,11 @@ def research_recommendation(
             raw = extract_final_text(message)
             return parse_response(raw), raw
         except Exception as e:
-            err = str(e)
+            err = str(e).lower()
+            # Billing/spend limit — no point retrying, exit immediately
+            if any(k in err for k in ("billing", "credit", "spend", "budget", "payment", "invoice", "limit_reached")):
+                print(f"\n💳  Billing limit reached — stopping. ({e})", file=sys.stderr)
+                sys.exit(2)
             if "rate_limit_error" in err and attempt < 2:
                 wait = 60 * (attempt + 1)
                 print(f"  Rate limit hit — waiting {wait}s before retry {attempt + 2}/3…", file=sys.stderr)

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -211,21 +211,13 @@ def research_recommendation(
     if web_search:
         kwargs["tools"] = [{"type": "web_search_20250305", "name": "web_search"}]
 
-    for attempt in range(3):
-        try:
-            message = client.messages.create(**kwargs)
-            raw = extract_final_text(message)
-            return parse_response(raw), raw
-        except Exception as e:
-            err = str(e)
-            if "rate_limit_error" in err and attempt < 2:
-                wait = 60 * (attempt + 1)
-                print(f"  Rate limit hit — waiting {wait}s before retry {attempt + 2}/3…", file=sys.stderr)
-                time.sleep(wait)
-            else:
-                print(f"  API error: {e}", file=sys.stderr)
-                return None, ""
-    return None, ""
+    try:
+        message = client.messages.create(**kwargs)
+        raw = extract_final_text(message)
+        return parse_response(raw), raw
+    except Exception as e:
+        print(f"  API error: {e}", file=sys.stderr)
+        return None, ""
 
 
 def write_audit_entry(audit_file: IO, rec: dict, result: dict | None, raw: str) -> None:
@@ -282,8 +274,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
-        help="Claude model ID (default: claude-haiku-4-5-20251001)",
+        default="claude-sonnet-4-6",
+        help="Claude model ID (default: claude-sonnet-4-6)",
     )
     args = parser.parse_args()
 
@@ -343,7 +335,7 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(65 if use_web_search else 0.3)  # web search uses ~25k tokens; wait >60s for TPM window
+                time.sleep(0.3)  # stay within rate limits
     finally:
         if audit_file:
             audit_file.close()

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -285,6 +285,13 @@ def main() -> None:
         default="claude-haiku-4-5-20251001",
         help="Claude model ID (default: claude-haiku-4-5-20251001)",
     )
+    parser.add_argument(
+        "--start-from",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Skip recommendations numbered below N within the filtered inquiry (default: 1, i.e. start from the beginning)",
+    )
     args = parser.parse_args()
 
     client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from environment
@@ -296,6 +303,11 @@ def main() -> None:
 
     if args.inquiry:
         unevidenced = [r for r in unevidenced if args.inquiry.lower() in r["inquiry"].lower()]
+
+    if args.start_from > 1:
+        before = len(unevidenced)
+        unevidenced = [r for r in unevidenced if r["rec_idx"] + 1 >= args.start_from]
+        print(f"--start-from {args.start_from}: skipped {before - len(unevidenced)} recs below that number", file=sys.stderr)
 
     total = len(unevidenced)
     print(f"{total} unevidenced recommendations", file=sys.stderr)
@@ -343,7 +355,7 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(65 if use_web_search else 0.3)  # web search uses ~25k tokens; wait >60s for TPM window
+                time.sleep(120 if use_web_search else 0.3)  # web search uses ~25k tokens; 2 min buffer clears 60s TPM window
     finally:
         if audit_file:
             audit_file.close()

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -67,25 +67,35 @@ ENRICHED_JSON = ROOT / "enriched_data.json"
 # Prompts
 # ---------------------------------------------------------------------------
 _PROMPT_BODY = """\
-You are helping research whether a UK public inquiry recommendation has been implemented by the government.
+You are checking whether a specific thing is in place in the UK.
 
 Inquiry: {inquiry}
 Report published: {report_date}
 Recommendation #{rec_num}: {rec_text}
 Category: {action_category} | Change type: {change_type}
 
-Task: Determine whether this specific recommendation was implemented.
-If it was, provide ONE piece of primary evidence — a direct URL to:
+Task: Find a URL showing that the thing described in the recommendation exists or is in operation.
+The source does NOT need to mention the inquiry — it just needs to show the thing is in place.
+Examples of what to look for:
+  - A new law or regulation → find the legislation
+  - A new body or regulator → find its website or founding document
+  - A new IT system or database → find a gov.uk page or announcement confirming it launched
+  - A new register or scheme → find the register or scheme page
+  - New guidance or standards → find the published guidance
+  - A training requirement → find the policy or framework document
+  - A structural or process change → find an official source confirming it is in effect
+
+The URL can point to:
   - Legislation (legislation.gov.uk)
-  - An official government report (gov.uk, parliament.uk, nao.org.uk, etc.)
+  - An official government publication or report (gov.uk, parliament.uk, nao.org.uk, etc.)
   - A press release or ministerial statement (gov.uk)
   - A parliamentary record (hansard.parliament.uk)
+  - A news article or credible public body page confirming the thing exists or happened
 
 Rules:
-- "Acceptance" or "welcome" by government is NOT implementation evidence.
-- Progress reports or reviews are NOT sufficient unless they confirm implementation.
-- If you cannot identify a specific, verifiable URL, respond with evidence_status "no_evidence_found".
-- Do not fabricate URLs — only provide URLs you have actually retrieved and confirmed exist.
+- Do not fabricate URLs — only return URLs you actually retrieved from search results.
+- If you did not find a URL, return no_evidence_found immediately. Do not write analysis.
+- A URL showing the thing exists is sufficient — it need not reference the inquiry.
 
 Respond in JSON only (no markdown fences):
 {{
@@ -96,19 +106,19 @@ Respond in JSON only (no markdown fences):
       "url": "https://...",
       "source_type": "legislation" | "press_release" | "official_report" | "parliamentary_record" | "news_article",
       "date": "YYYY-MM-DD or null",
-      "description": "1-2 sentences explaining how this evidences the recommendation being implemented",
+      "description": "1-2 sentences on how this URL relates to the recommendation",
       "evidence_type": "complete" | "partial"
     }}
   ],
-  "notes": "brief research notes explaining your reasoning"
+  "notes": "one sentence max"
 }}
 
 evidence_type rules:
-- "complete" — recommendation is fully implemented (law enacted, scheme operational, guidance published and in force)
-- "partial"  — progress is visible but implementation is incomplete, paused, or only promised
+- "complete" — recommendation is fully implemented (law enacted, scheme operational, guidance in force)
+- "partial"  — some progress visible but implementation incomplete or partial
 
-If not found:
-{{"evidence_status": "no_evidence_found", "evidence": [], "notes": "reason"}}
+If no URL found:
+{{"evidence_status": "no_evidence_found", "evidence": [], "notes": "No relevant URL found."}}
 """
 
 RESEARCH_PROMPT = _PROMPT_BODY
@@ -209,7 +219,7 @@ def research_recommendation(
         "messages": [{"role": "user", "content": prompt}],
     }
     if web_search:
-        kwargs["tools"] = [{"type": "web_search_20250305", "name": "web_search"}]
+        kwargs["tools"] = [{"type": "web_search_20250305", "name": "web_search", "max_uses": 1}]
 
     for attempt in range(3):
         try:

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -219,7 +219,7 @@ def research_recommendation(
         except Exception as e:
             err = str(e)
             if "rate_limit_error" in err and attempt < 2:
-                wait = 30 * (attempt + 1)
+                wait = 60 * (attempt + 1)
                 print(f"  Rate limit hit — waiting {wait}s before retry {attempt + 2}/3…", file=sys.stderr)
                 time.sleep(wait)
             else:
@@ -343,7 +343,7 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(5 if use_web_search else 0.3)  # web search responses are larger
+                time.sleep(65 if use_web_search else 0.3)  # web search uses ~25k tokens; wait >60s for TPM window
     finally:
         if audit_file:
             audit_file.close()

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -235,8 +235,16 @@ def research_recommendation(
                 print(f"\n💳  Billing limit reached — stopping. ({e})", file=sys.stderr)
                 sys.exit(2)
             if "rate_limit_error" in err and attempt < 2:
-                wait = 60 * (attempt + 1)
-                print(f"  Rate limit hit — waiting {wait}s before retry {attempt + 2}/3…", file=sys.stderr)
+                # Use retry-after header if available, otherwise fall back to fixed waits
+                retry_after = None
+                if hasattr(e, "response") and e.response is not None:
+                    try:
+                        retry_after = int(e.response.headers.get("retry-after", 0)) or None
+                    except (ValueError, AttributeError):
+                        pass
+                wait = retry_after if retry_after else 60 * (attempt + 1)
+                source = "retry-after header" if retry_after else "fallback"
+                print(f"  Rate limit hit — waiting {wait}s ({source}) before retry {attempt + 2}/3…", file=sys.stderr)
                 time.sleep(wait)
             else:
                 print(f"  API error: {e}", file=sys.stderr)
@@ -374,7 +382,16 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(150 if use_web_search else 0.3)  # web search can use 60k+ tokens; 150s clears the 60s TPM window
+                if use_web_search:
+                    # Dynamic sleep: tokens used / ITPM_limit * 60s + 15s buffer
+                    # Haiku Tier 1 = 50k ITPM. Use actual token count if available.
+                    itpm = 50_000
+                    input_toks = token_info.get("input_tokens", itpm) if token_info else itpm
+                    dynamic_sleep = max(60, int(input_toks / itpm * 60) + 15)
+                    print(f"  sleeping {dynamic_sleep}s ({input_toks:,} tokens / {itpm:,} ITPM)…", file=sys.stderr)
+                    time.sleep(dynamic_sleep)
+                else:
+                    time.sleep(0.3)
     finally:
         if audit_file:
             audit_file.close()

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -191,7 +191,7 @@ def research_recommendation(
     rec: dict,
     model: str,
     web_search: bool = True,
-) -> tuple[dict | None, str]:
+) -> tuple[dict | None, str, dict]:
     """Returns (parsed_result, raw_response_text)."""
     prompt_template = RESEARCH_PROMPT_WEB if web_search else RESEARCH_PROMPT
     prompt = prompt_template.format(
@@ -215,7 +215,19 @@ def research_recommendation(
         try:
             message = client.messages.create(**kwargs)
             raw = extract_final_text(message)
-            return parse_response(raw), raw
+            usage = message.usage
+            n_searches = sum(1 for b in message.content if getattr(b, "type", "") == "tool_use")
+            token_info = {
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "web_searches": n_searches,
+            }
+            print(
+                f"  tokens: {usage.input_tokens:,} in / {usage.output_tokens:,} out"
+                + (f" | {n_searches} web search(es)" if web_search else ""),
+                file=sys.stderr,
+            )
+            return parse_response(raw), raw, token_info
         except Exception as e:
             err = str(e).lower()
             # Billing/spend limit — no point retrying, exit immediately
@@ -228,11 +240,11 @@ def research_recommendation(
                 time.sleep(wait)
             else:
                 print(f"  API error: {e}", file=sys.stderr)
-                return None, ""
-    return None, ""
+                return None, "", {}
+    return None, "", {}
 
 
-def write_audit_entry(audit_file: IO, rec: dict, result: dict | None, raw: str) -> None:
+def write_audit_entry(audit_file: IO, rec: dict, result: dict | None, raw: str, token_info: dict | None = None) -> None:
     """Append one JSONL entry to the audit log."""
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -243,6 +255,9 @@ def write_audit_entry(audit_file: IO, rec: dict, result: dict | None, raw: str) 
         "outcome": (result or {}).get("evidence_status", "parse_error"),
         "notes": (result or {}).get("notes", ""),
         "evidence_count": len((result or {}).get("evidence", [])),
+        "input_tokens": (token_info or {}).get("input_tokens"),
+        "output_tokens": (token_info or {}).get("output_tokens"),
+        "web_searches": (token_info or {}).get("web_searches"),
         "raw_response": raw,
     }
     audit_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
@@ -333,10 +348,10 @@ def main() -> None:
             label = f"[{i + 1}/{len(batch)}] {rec['inquiry']} rec {rec['rec_idx'] + 1}"
             print(label, file=sys.stderr)
 
-            result, raw = research_recommendation(client, rec, args.model, web_search=use_web_search)
+            result, raw, token_info = research_recommendation(client, rec, args.model, web_search=use_web_search)
 
             if audit_file:
-                write_audit_entry(audit_file, rec, result, raw)
+                write_audit_entry(audit_file, rec, result, raw, token_info)
 
             if result and result.get("evidence_status") in ("actioned", "partial") and result.get("evidence"):
                 for ev in result["evidence"]:

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -359,7 +359,7 @@ def main() -> None:
                         print(f"     {line}", file=sys.stderr)
 
             if i < len(batch) - 1:
-                time.sleep(120 if use_web_search else 0.3)  # web search uses ~25k tokens; 2 min buffer clears 60s TPM window
+                time.sleep(150 if use_web_search else 0.3)  # web search can use 60k+ tokens; 150s clears the 60s TPM window
     finally:
         if audit_file:
             audit_file.close()

--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -71,7 +71,7 @@ def index():
         pending_items = [
             (i, item)
             for i, item in enumerate(entry.get("evidence", []))
-            if not item.get("approved")
+            if not item.get("approved") and not item.get("rejected")
         ]
         if pending_items:
             pending.append({
@@ -96,7 +96,7 @@ def index():
         for entry in enriched.values()
         if isinstance(entry, dict)
         for item in entry.get("evidence", [])
-        if not item.get("approved")
+        if not item.get("approved") and not item.get("rejected")
     )
     total_approved = sum(
         1
@@ -189,7 +189,11 @@ def approve_all():
 
 @app.route("/reject", methods=["POST"])
 def reject():
-    """Remove a single evidence item from a key."""
+    """
+    Reject a single evidence item: strip it to {url, rejected:true} to prevent
+    the research script re-proposing the same URL, without bloating the JSON.
+    If the item had no URL, remove it entirely.
+    """
     data = request.get_json()
     key = data.get("key")
     item_index = data.get("item_index")
@@ -203,14 +207,22 @@ def reject():
     if not isinstance(item_index, int) or item_index < 0 or item_index >= len(items):
         return jsonify({"ok": False, "error": "Index out of range"}), 400
 
-    removed = items.pop(item_index)
+    item = items[item_index]
+    url = item.get("url", "")
+    title = item.get("title", "")
 
-    # If no evidence remains, remove the key entirely
+    if url:
+        # Shrink to URL-only tombstone — preserves dedup, drops all bulk
+        items[item_index] = {"url": url, "rejected": True}
+    else:
+        items.pop(item_index)
+
+    # If nothing remains at all, remove the key
     if not items:
         del enriched[key]
 
     save_enriched(enriched)
-    return jsonify({"ok": True, "removed_title": removed.get("title", "")})
+    return jsonify({"ok": True, "title": title})
 
 
 @app.route("/edit", methods=["POST"])

--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -212,7 +212,7 @@ def reject():
     title = item.get("title", "")
 
     if url:
-        # Shrink to URL-only tombstone — preserves dedup, drops all bulk
+        # Shrink to URL-only rejected marker — preserves dedup, drops all bulk
         items[item_index] = {"url": url, "rejected": True}
     else:
         items.pop(item_index)


### PR DESCRIPTION
## Summary

- **research.py**: web search on by default (`web_search_20250305` tool, `max_uses: 1`), audit log (`--audit-log`), rate-limit retry with `retry-after` header, dynamic inter-request sleep from token count, billing-limit exit, `--start-from` flag, reframed prompt (find evidence the thing exists, not that government responded), Haiku as default model
- **batch_research.py**: full sweep script across all 21 inquiries with pacing gates
- **review app**: reject endpoint shrinks item to `{url, rejected: true}` marker to prevent re-proposal on future research runs
- **CI**: approved check and URL check now skip `rejected: true` items
- **index.html / .gitignore**: Buy Me a Token BMC widget; ignore `*.jsonl` audit logs and `data/` PDFs
- **scripts/README.md**: updated usage docs, rejection standards section

