### PR TITLE
Fix: review app rec text lookup off by one

### DIFF
--- a/tools/review_app/app.py
+++ b/tools/review_app/app.py
@@ -45,7 +45,7 @@ def load_recommendations():
     for dept in data:
         for inquiry in dept.get("Inquiries", []):
             name = inquiry["InquiryName"]
-            for i, rec in enumerate(inquiry.get("Recommendations", []), 1):
+            for i, rec in enumerate(inquiry.get("Recommendations", [])):
                 recs[f"{name}__{i}"] = rec["Recommendation"]
     return recs
 


### PR DESCRIPTION
`load_recommendations()` built keys using `enumerate(..., 1)` (1-based) but `research.py` writes `enriched_data.json` keys using `enumerate(...)` (0-based), so every lookup was off by one and all AI-generated entries showed "(recommendation text not found)".

One-character fix: remove the `, 1` start argument.